### PR TITLE
feat: unified asset manager for custom fonts and brand assets

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -336,8 +336,8 @@ it via `remove_font`):
   - fonts: woff2 magic bytes (`wOF2`);
   - images: extension allowlist `jpg jpeg png webp avif svg gif ico`,
     path components rejected;
-  - the gate deletes the tmp file on every rejection (callers never
-    clean up).
+  - the gate deletes the tmp file on every rejection (front-end callers
+    never clean up).
 - Front-end plumbing lives in `utils/asset-upload.js` (dropzone, progress
   row, delete confirm, cgi-upload XHR); `view/aurora/theme.js` composes it
   for both the Custom Fonts and Brand Asset Library sections.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -330,7 +330,7 @@ Users can upload their own woff2 via the `upload_font` RPC method (and remove
 it via `remove_font`):
 
 - Upload goes through cgi-io to `/tmp/aurora_font.tmp`.
-- Server-side validation: woff2 magic bytes (`wOF2`), size ≤ 4MB.
+- Server-side validation: woff2 magic bytes (`wOF2`), size ≤ 8MB.
 - Stored under `/www/luci-static/aurora/fonts/custom/<slot>-<slug>.{woff2,meta,face}`
   (`.face` is the pre-rendered `@font-face` block, `.meta` carries the
   display family + font stack).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -329,8 +329,18 @@ the built-in face is used instead).
 Users can upload their own woff2 via the `upload_font` RPC method (and remove
 it via `remove_font`):
 
-- Upload goes through cgi-io to `/tmp/aurora_font.tmp`.
-- Server-side validation: woff2 magic bytes (`wOF2`), size ≤ 8MB.
+- Upload goes through cgi-io to `/tmp/aurora_font.tmp` (fonts) or
+  `/tmp/aurora_icon.tmp` (brand assets), then a `receive_upload` gate in
+  the rpcd script validates before anything touches flash:
+  - shared size cap: 8MB (`MAX_UPLOAD`);
+  - fonts: woff2 magic bytes (`wOF2`);
+  - images: extension allowlist `jpg jpeg png webp avif svg gif ico`,
+    path components rejected;
+  - the gate deletes the tmp file on every rejection (callers never
+    clean up).
+- Front-end plumbing lives in `utils/asset-upload.js` (dropzone, progress
+  row, delete confirm, cgi-upload XHR); `view/aurora/theme.js` composes it
+  for both the Custom Fonts and Brand Asset Library sections.
 - Stored under `/www/luci-static/aurora/fonts/custom/<slot>-<slug>.{woff2,meta,face}`
   (`.face` is the pre-rendered `@font-face` block, `.meta` carries the
   display family + font stack).

--- a/htdocs/luci-static/resources/utils/asset-upload.js
+++ b/htdocs/luci-static/resources/utils/asset-upload.js
@@ -224,11 +224,11 @@ return baseclass.extend({
             },
             cfg.bar.sub || "",
           ),
-          input,
         ],
       );
 
       dock.appendChild(bar);
+      dock.appendChild(input);
     };
 
     const buildForm = (file, check) => {

--- a/htdocs/luci-static/resources/utils/asset-upload.js
+++ b/htdocs/luci-static/resources/utils/asset-upload.js
@@ -77,18 +77,20 @@ return baseclass.extend({
     });
   },
 
-  // Composite "asset manager": a table (preview | name | badge | size | ✕)
-  // sitting on a dock that shows either the slim upload bar, the in-place
-  // confirm form, or a progress row -- never more than one at a time. Both
-  // custom-fonts and the brand asset library render through this; the only
-  // per-kind knowledge lives in the caller's row/bar/form/checkFile/upload
-  // callbacks. See prototype v3 variant A (font-upload-proto.html) for the
-  // interaction blueprint this replicates.
+  // Composite "asset manager": a native LuCI `.table` (preview | name |
+  // badge | size | delete) sitting on a dock that shows either the slim
+  // upload bar, the in-place confirm form, or a progress row -- never more
+  // than one at a time. Both custom-fonts and the brand asset library
+  // render through this; the only per-kind knowledge lives in the caller's
+  // row/bar/form/checkFile/upload callbacks. Table markup deliberately
+  // mirrors the theme's other cbi tables (`table` / `tr table-titles` /
+  // `th` / `tr` / `td`) so it inherits the Aurora theme's colors, dark
+  // mode, and row hover instead of fighting it with bespoke inline chrome.
   //
   // cfg = {
   //   badgeHeader,                 // _("Slot") or _("Type")
   //   emptyText,
-  //   rows: [{ preview, name, badge: { label, tone }, size, onDelete() }],
+  //   rows: [{ preview, name, badge, size, onDelete() }],  // badge: plain text or falsy
   //   bar: { hint, sub, accept },
   //   checkFile(file) -> { ok, err },
   //   form: { fields(file) -> { el, value(), valid() }, note },
@@ -97,108 +99,65 @@ return baseclass.extend({
   // }
   createAssetManager(cfg) {
     const rows = cfg.rows || [];
-    const th = (width) =>
-      "text-align:left;font-size:0.72em;color:var(--text-muted);" +
-      "font-weight:600;letter-spacing:0.03em;padding:0.4em 0.75em;" +
-      "background:var(--surface-sunken);border-bottom:1px solid var(--hairline);" +
-      (width ? "width:" + width + "px;" : "");
-    const td =
-      "padding:0.45em 0.75em;border-bottom:1px solid var(--hairline);" +
-      "vertical-align:middle;";
-    const badgeStyle = (tone) =>
-      "display:inline-block;font-size:0.68em;font-weight:700;" +
-      "letter-spacing:0.03em;padding:0.08em 0.55em;border-radius:999px;" +
-      "white-space:nowrap;" +
-      (tone === "brand"
-        ? "background:var(--brand-subtle);color:var(--brand);"
-        : "background:var(--surface-sunken);color:var(--text-muted);" +
-          "border:1px solid var(--hairline);");
 
-    const shell = E("div", {
-      style:
-        "border:1px solid var(--hairline);border-radius:var(--radius-base);" +
-        "overflow:hidden;",
-    });
+    const shell = E("div", {});
 
     if (rows.length) {
       shell.appendChild(
-        E(
-          "table",
-          { style: "width:100%;border-collapse:collapse;font-size:0.9em;" },
-          [
-            E("thead", {}, [
-              E("tr", {}, [
-                E("th", { style: th(40) }, ""),
-                E("th", { style: th() }, _("Name")),
-                E("th", { style: th(76) }, cfg.badgeHeader),
-                E("th", { style: th(84) }, _("Size")),
-                E("th", { style: th(40) }, ""),
-              ]),
-            ]),
-            E(
-              "tbody",
-              {},
-              rows.map((row) =>
-                E("tr", {}, [
-                  E("td", { style: td }, row.preview),
-                  E(
-                    "td",
-                    { style: td + "font-weight:600;word-break:break-all;" },
-                    row.name,
-                  ),
-                  E(
-                    "td",
-                    { style: td },
-                    row.badge
-                      ? E(
-                          "span",
-                          { style: badgeStyle(row.badge.tone) },
-                          row.badge.label,
-                        )
-                      : "",
-                  ),
-                  E(
-                    "td",
-                    {
-                      style:
-                        td +
-                        "color:var(--text-muted);font-variant-numeric:tabular-nums;" +
-                        "white-space:nowrap;",
-                    },
-                    formatSize(row.size || 0),
-                  ),
-                  E(
-                    "td",
-                    { style: td },
-                    E(
-                      "button",
-                      {
-                        type: "button",
-                        class: "cbi-button",
-                        title: _("Delete"),
-                        style: "padding:0.15em 0.5em;line-height:1;",
-                        click: row.onDelete,
-                      },
-                      "✕",
-                    ),
-                  ),
-                ]),
+        E("table", { class: "table" }, [
+          E("tr", { class: "tr table-titles" }, [
+            E("th", { class: "th", style: "width:56px;" }, ""),
+            E("th", { class: "th" }, _("Name")),
+            E("th", { class: "th" }, cfg.badgeHeader),
+            E("th", { class: "th" }, _("Size")),
+            E("th", { class: "th center" }, ""),
+          ]),
+          ...rows.map((row) =>
+            E("tr", { class: "tr" }, [
+              E("td", { class: "td" }, row.preview),
+              E(
+                "td",
+                { class: "td", style: "word-break:break-all;" },
+                row.name,
               ),
-            ),
-          ],
-        ),
+              E(
+                "td",
+                {
+                  class: "td",
+                  style: "color:var(--text-muted);font-size:0.9em;",
+                },
+                row.badge || "",
+              ),
+              E(
+                "td",
+                {
+                  class: "td",
+                  style:
+                    "color:var(--text-muted);font-variant-numeric:tabular-nums;" +
+                    "white-space:nowrap;",
+                },
+                formatSize(row.size || 0),
+              ),
+              E(
+                "td",
+                { class: "td center" },
+                E(
+                  "button",
+                  {
+                    type: "button",
+                    class: "cbi-button cbi-button-remove",
+                    click: row.onDelete,
+                  },
+                  _("Delete"),
+                ),
+              ),
+            ]),
+          ),
+        ]),
       );
     } else {
       shell.appendChild(
-        E(
-          "div",
-          {
-            style:
-              "padding:0.75em 0.9em;color:var(--text-muted);font-size:0.9em;" +
-              "border-bottom:1px solid var(--hairline);",
-          },
-          cfg.emptyText,
-        ),
+        E("div", { style: "padding:0.5em 0;" }, [E("em", {}, cfg.emptyText)]),
       );
     }
 
@@ -228,36 +187,26 @@ return baseclass.extend({
           type: "button",
           style:
             "display:flex;align-items:center;gap:0.6em;width:100%;" +
-            "padding:0.6em 0.9em;background:var(--surface-sunken);" +
-            "border:0;border-top:1px solid var(--hairline);text-align:left;" +
-            "cursor:pointer;color:var(--text);font:inherit;",
+            "margin-top:0.5em;padding:0.6em 0.9em;background:transparent;" +
+            "border:1px dashed var(--hairline);border-radius:var(--radius-base);" +
+            "text-align:left;cursor:pointer;color:var(--text);font:inherit;",
           click: () => input.click(),
           dragover: (e) => {
             e.preventDefault();
-            bar.style.background = "var(--brand-subtle)";
+            bar.style.background = "var(--surface-sunken)";
           },
           dragleave: () => {
-            bar.style.background = "var(--surface-sunken)";
+            bar.style.background = "transparent";
           },
           drop: (e) => {
             e.preventDefault();
-            bar.style.background = "var(--surface-sunken)";
+            bar.style.background = "transparent";
             const file = e.dataTransfer && e.dataTransfer.files[0];
             if (file) onFile(file);
           },
         },
         [
-          E(
-            "span",
-            {
-              style:
-                "width:26px;height:26px;border-radius:0.4em;flex:0 0 auto;" +
-                "background:var(--brand-subtle);color:var(--brand);" +
-                "display:flex;align-items:center;justify-content:center;" +
-                "font-weight:800;",
-            },
-            "⬆",
-          ),
+          E("span", { style: "font-weight:700;" }, "⬆"),
           E("strong", { style: "font-size:0.93em;" }, cfg.bar.hint),
           E("span", { style: "flex:1;" }, ""),
           E(
@@ -407,7 +356,7 @@ return baseclass.extend({
         "div",
         {
           style:
-            "padding:0.75em 0.9em;background:var(--surface-sunken);" +
+            "margin-top:0.5em;padding-top:0.6em;" +
             "border-top:1px solid var(--hairline);display:flex;" +
             "flex-direction:column;gap:0.6em;",
         },

--- a/htdocs/luci-static/resources/utils/asset-upload.js
+++ b/htdocs/luci-static/resources/utils/asset-upload.js
@@ -22,6 +22,8 @@ return baseclass.extend({
 
   formatSize,
 
+  extOf,
+
   // Pure pre-check for instant feedback; the rpcd receive_upload gate stays
   // authoritative. exts is a lowercase list without dots, e.g. ["woff2"].
   checkFile(file, opts) {
@@ -73,129 +75,6 @@ return baseclass.extend({
       xhr.withCredentials = true;
       xhr.send(formData);
     });
-  },
-
-  // Persistent dropzone: click / drag-drop / keyboard. Returns the element
-  // with a setBusy(bool) method for the upload-in-flight state.
-  createDropzone(opts) {
-    const input = E("input", {
-      type: "file",
-      style: "display:none",
-      accept: opts.accept || "",
-    });
-    input.addEventListener("change", () => {
-      const file = input.files && input.files[0];
-      input.value = "";
-      if (file) opts.onFile(file);
-    });
-
-    const zone = E(
-      "div",
-      {
-        style:
-          "border:2px dashed var(--hairline);border-radius:0.5em;padding:" +
-          (opts.compact ? "0.9em 1em" : "1.25em 1em") +
-          ";text-align:center;cursor:pointer;transition:border-color 0.15s,background 0.15s;",
-        tabindex: "0",
-        role: "button",
-        click: () => input.click(),
-        keydown: (e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            input.click();
-          }
-        },
-        dragover: (e) => {
-          e.preventDefault();
-          zone.style.borderColor = "var(--brand)";
-          zone.style.background = "var(--brand-subtle)";
-        },
-        dragleave: () => {
-          zone.style.borderColor = "";
-          zone.style.background = "";
-        },
-        drop: (e) => {
-          e.preventDefault();
-          zone.style.borderColor = "";
-          zone.style.background = "";
-          const file = e.dataTransfer && e.dataTransfer.files[0];
-          if (file) opts.onFile(file);
-        },
-      },
-      [
-        E(
-          "div",
-          { style: "font-size:1.5em;margin-bottom:0.25em;pointer-events:none;" },
-          "⬆",
-        ),
-        E("strong", { style: "pointer-events:none;" }, opts.hint),
-        opts.sub
-          ? E(
-              "div",
-              {
-                style:
-                  "font-size:0.8em;opacity:0.6;margin-top:0.25em;pointer-events:none;",
-              },
-              opts.sub,
-            )
-          : "",
-        input,
-      ],
-    );
-
-    zone.setBusy = (busy) => {
-      zone.style.opacity = busy ? "0.5" : "";
-      zone.style.pointerEvents = busy ? "none" : "";
-    };
-    return zone;
-  },
-
-  createProgressRow() {
-    const bar = E("div", {
-      style:
-        "height:100%;width:0%;transition:width 0.15s;border-radius:2px;background:var(--brand);",
-    });
-    const filename = E("span", {}, "");
-    const pct = E("span", {}, "0%");
-    const el = E(
-      "div",
-      {
-        style:
-          "display:none;margin-bottom:0.75em;padding:0.6em 0.875em;border-radius:0.375em;border:1px solid var(--hairline);",
-      },
-      [
-        E(
-          "div",
-          {
-            style:
-              "display:flex;justify-content:space-between;align-items:center;font-size:0.85em;margin-bottom:0.4em;",
-          },
-          [filename, pct],
-        ),
-        E(
-          "div",
-          {
-            style:
-              "height:4px;border-radius:2px;overflow:hidden;background:var(--surface-sunken);",
-          },
-          [bar],
-        ),
-      ],
-    );
-    return {
-      el,
-      set(p, name) {
-        if (name != null) filename.textContent = name;
-        bar.style.width = p + "%";
-        pct.textContent = p + "%";
-      },
-      show() {
-        el.style.display = "block";
-      },
-      hide() {
-        el.style.display = "none";
-      },
-    };
   },
 
   // Composite "asset manager": a table (preview | name | badge | size | ✕)

--- a/htdocs/luci-static/resources/utils/asset-upload.js
+++ b/htdocs/luci-static/resources/utils/asset-upload.js
@@ -1,0 +1,228 @@
+"use strict";
+"require baseclass";
+"require rpc";
+"require ui";
+
+// Shared upload plumbing for the config UI. Two surfaces consume it (custom
+// fonts, brand asset library); anything font- or image-specific stays with
+// the caller -- this module only knows about files, bytes, and the
+// cgi-upload channel.
+
+const MAX_UPLOAD = 8 * 1024 * 1024;
+
+const formatSize = (bytes) => (bytes / 1048576).toFixed(1) + " MB";
+
+return baseclass.extend({
+  MAX_UPLOAD,
+
+  formatSize,
+
+  // Pure pre-check for instant feedback; the rpcd receive_upload gate stays
+  // authoritative. exts is a lowercase list without dots, e.g. ["woff2"].
+  checkFile(file, opts) {
+    const exts = opts?.exts || [];
+    const ext = (file.name.match(/\.([a-z0-9]+)$/i)?.[1] || "").toLowerCase();
+    if (exts.length && !exts.includes(ext))
+      return {
+        ok: false,
+        err: _("Unsupported file type. Allowed: %s").format(exts.join(", ")),
+      };
+    if (file.size > MAX_UPLOAD)
+      return {
+        ok: false,
+        err: _("File is %s, exceeding the 8MB limit.").format(
+          formatSize(file.size),
+        ),
+      };
+    return { ok: true, err: "" };
+  },
+
+  // XHR to /cgi-bin/cgi-upload. Resolves on HTTP 200; the caller still has
+  // to run its own RPC confirm (upload_font / upload_icon) afterwards.
+  uploadToRouter(opts) {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+
+      if (opts.onProgress)
+        xhr.upload.addEventListener("progress", (e) => {
+          if (e.lengthComputable)
+            opts.onProgress(Math.round((e.loaded / e.total) * 100));
+        });
+
+      xhr.addEventListener("load", () =>
+        xhr.status === 200
+          ? resolve()
+          : reject(new Error(_("Upload failed (HTTP %s)").format(xhr.status))),
+      );
+      xhr.addEventListener("error", () =>
+        reject(new Error(_("Upload failed"))),
+      );
+
+      const formData = new FormData();
+      formData.append("sessionid", rpc.getSessionID());
+      formData.append("filename", opts.tmpPath);
+      formData.append("filemode", "0600");
+      formData.append("filedata", opts.file, opts.file.name);
+
+      xhr.open("POST", "/cgi-bin/cgi-upload");
+      xhr.withCredentials = true;
+      xhr.send(formData);
+    });
+  },
+
+  // Persistent dropzone: click / drag-drop / keyboard. Returns the element
+  // with a setBusy(bool) method for the upload-in-flight state.
+  createDropzone(opts) {
+    const input = E("input", {
+      type: "file",
+      style: "display:none",
+      accept: opts.accept || "",
+    });
+    input.addEventListener("change", () => {
+      const file = input.files && input.files[0];
+      input.value = "";
+      if (file) opts.onFile(file);
+    });
+
+    const zone = E(
+      "div",
+      {
+        style:
+          "border:2px dashed var(--hairline);border-radius:0.5em;padding:" +
+          (opts.compact ? "0.9em 1em" : "1.25em 1em") +
+          ";text-align:center;cursor:pointer;transition:border-color 0.15s,background 0.15s;",
+        tabindex: "0",
+        role: "button",
+        click: () => input.click(),
+        keydown: (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            input.click();
+          }
+        },
+        dragover: (e) => {
+          e.preventDefault();
+          zone.style.borderColor = "var(--brand)";
+          zone.style.background = "var(--brand-subtle)";
+        },
+        dragleave: () => {
+          zone.style.borderColor = "";
+          zone.style.background = "";
+        },
+        drop: (e) => {
+          e.preventDefault();
+          zone.style.borderColor = "";
+          zone.style.background = "";
+          const file = e.dataTransfer && e.dataTransfer.files[0];
+          if (file) opts.onFile(file);
+        },
+      },
+      [
+        E(
+          "div",
+          { style: "font-size:1.5em;margin-bottom:0.25em;pointer-events:none;" },
+          "⬆",
+        ),
+        E("strong", { style: "pointer-events:none;" }, opts.hint),
+        opts.sub
+          ? E(
+              "div",
+              {
+                style:
+                  "font-size:0.8em;opacity:0.6;margin-top:0.25em;pointer-events:none;",
+              },
+              opts.sub,
+            )
+          : "",
+        input,
+      ],
+    );
+
+    zone.setBusy = (busy) => {
+      zone.style.opacity = busy ? "0.5" : "";
+      zone.style.pointerEvents = busy ? "none" : "";
+    };
+    return zone;
+  },
+
+  createProgressRow() {
+    const bar = E("div", {
+      style:
+        "height:100%;width:0%;transition:width 0.15s;border-radius:2px;background:var(--brand);",
+    });
+    const filename = E("span", {}, "");
+    const pct = E("span", {}, "0%");
+    const el = E(
+      "div",
+      {
+        style:
+          "display:none;margin-bottom:0.75em;padding:0.6em 0.875em;border-radius:0.375em;border:1px solid var(--hairline);",
+      },
+      [
+        E(
+          "div",
+          {
+            style:
+              "display:flex;justify-content:space-between;align-items:center;font-size:0.85em;margin-bottom:0.4em;",
+          },
+          [filename, pct],
+        ),
+        E(
+          "div",
+          {
+            style:
+              "height:4px;border-radius:2px;overflow:hidden;background:var(--surface-sunken);",
+          },
+          [bar],
+        ),
+      ],
+    );
+    return {
+      el,
+      set(p, name) {
+        if (name != null) filename.textContent = name;
+        bar.style.width = p + "%";
+        pct.textContent = p + "%";
+      },
+      show() {
+        el.style.display = "block";
+      },
+      hide() {
+        el.style.display = "none";
+      },
+    };
+  },
+
+  confirmDelete(opts) {
+    return new Promise((resolve) => {
+      ui.showModal(opts.title, [
+        E("p", {}, opts.message),
+        E("div", { class: "right" }, [
+          E(
+            "button",
+            {
+              class: "btn",
+              click: () => {
+                ui.hideModal();
+                resolve(false);
+              },
+            },
+            _("Cancel"),
+          ),
+          " ",
+          E(
+            "button",
+            {
+              class: "btn cbi-button-negative",
+              click: () => {
+                ui.hideModal();
+                resolve(true);
+              },
+            },
+            _("Delete"),
+          ),
+        ]),
+      ]);
+    });
+  },
+});

--- a/htdocs/luci-static/resources/utils/asset-upload.js
+++ b/htdocs/luci-static/resources/utils/asset-upload.js
@@ -186,32 +186,42 @@ return baseclass.extend({
         {
           type: "button",
           style:
-            "display:flex;align-items:center;gap:0.6em;width:100%;" +
-            "margin-bottom:0.5em;padding:0.6em 0.9em;background:transparent;" +
-            "border:1px dashed var(--hairline);border-radius:var(--radius-base);" +
-            "text-align:left;cursor:pointer;color:var(--text);font:inherit;",
+            "display:block;width:100%;" +
+            "border:2px dashed var(--hairline);border-radius:0.5em;" +
+            "padding:1.25em 1em;text-align:center;cursor:pointer;" +
+            "margin-bottom:0.75em;" +
+            "transition:border-color 0.15s,background 0.15s;",
           click: () => input.click(),
           dragover: (e) => {
             e.preventDefault();
-            bar.style.background = "var(--surface-sunken)";
+            bar.style.borderColor = "var(--brand)";
+            bar.style.background = "var(--brand-subtle)";
           },
           dragleave: () => {
-            bar.style.background = "transparent";
+            bar.style.borderColor = "";
+            bar.style.background = "";
           },
           drop: (e) => {
             e.preventDefault();
-            bar.style.background = "transparent";
+            bar.style.borderColor = "";
+            bar.style.background = "";
             const file = e.dataTransfer && e.dataTransfer.files[0];
             if (file) onFile(file);
           },
         },
         [
-          E("span", { style: "font-weight:700;" }, "⬆"),
-          E("strong", { style: "font-size:0.93em;" }, cfg.bar.hint),
-          E("span", { style: "flex:1;" }, ""),
           E(
-            "span",
-            { style: "color:var(--text-muted);font-size:0.89em;" },
+            "div",
+            { style: "font-size:1.5em;margin-bottom:0.25em;pointer-events:none;" },
+            "⬆",
+          ),
+          E("strong", { style: "pointer-events:none;" }, cfg.bar.hint),
+          E(
+            "div",
+            {
+              style:
+                "font-size:0.8em;opacity:0.6;margin-top:0.25em;pointer-events:none;",
+            },
             cfg.bar.sub || "",
           ),
           input,

--- a/htdocs/luci-static/resources/utils/asset-upload.js
+++ b/htdocs/luci-static/resources/utils/asset-upload.js
@@ -13,7 +13,7 @@ const MAX_UPLOAD = 8 * 1024 * 1024;
 const formatSize = (bytes) =>
   bytes >= 1048576
     ? (bytes / 1048576).toFixed(1) + " MB"
-    : Math.round(bytes / 1024) + " KB";
+    : Math.max(1, Math.round(bytes / 1024)) + " KB";
 
 const extOf = (name) => (name.match(/\.([a-z0-9]+)$/i)?.[1] || "").toLowerCase();
 
@@ -28,7 +28,7 @@ return baseclass.extend({
   // authoritative. exts is a lowercase list without dots, e.g. ["woff2"].
   checkFile(file, opts) {
     const exts = opts?.exts || [];
-    const ext = (file.name.match(/\.([a-z0-9]+)$/i)?.[1] || "").toLowerCase();
+    const ext = extOf(file.name);
     if (exts.length && !exts.includes(ext))
       return {
         ok: false,
@@ -102,6 +102,9 @@ return baseclass.extend({
 
     const shell = E("div", {});
 
+    const dock = E("div", {});
+    shell.appendChild(dock);
+
     if (rows.length) {
       shell.appendChild(
         E("table", { class: "table" }, [
@@ -161,9 +164,6 @@ return baseclass.extend({
       );
     }
 
-    const dock = E("div", {});
-    shell.appendChild(dock);
-
     const clearDock = () => {
       while (dock.firstChild) dock.firstChild.remove();
     };
@@ -187,7 +187,7 @@ return baseclass.extend({
           type: "button",
           style:
             "display:flex;align-items:center;gap:0.6em;width:100%;" +
-            "margin-top:0.5em;padding:0.6em 0.9em;background:transparent;" +
+            "margin-bottom:0.5em;padding:0.6em 0.9em;background:transparent;" +
             "border:1px dashed var(--hairline);border-radius:var(--radius-base);" +
             "text-align:left;cursor:pointer;color:var(--text);font:inherit;",
           click: () => input.click(),
@@ -249,6 +249,27 @@ return baseclass.extend({
         setProgress(0);
       };
 
+      let busy = false;
+      const setFieldsDisabled = (disabled) => {
+        fields.el
+          .querySelectorAll("input, select, textarea")
+          .forEach((el) => {
+            el.disabled = disabled;
+          });
+      };
+
+      const removeBtn = E(
+        "button",
+        {
+          type: "button",
+          class: "cbi-button",
+          title: _("Remove file"),
+          style: "padding:0.15em 0.5em;line-height:1;",
+          click: renderBar,
+        },
+        "✕",
+      );
+
       const fileLine = E(
         "div",
         { style: "display:flex;align-items:center;gap:0.55em;" },
@@ -281,17 +302,7 @@ return baseclass.extend({
             formatSize(file.size),
           ),
           E("span", { style: "flex:1;" }, ""),
-          E(
-            "button",
-            {
-              type: "button",
-              class: "cbi-button",
-              title: _("Remove file"),
-              style: "padding:0.15em 0.5em;line-height:1;",
-              click: renderBar,
-            },
-            "✕",
-          ),
+          removeBtn,
         ],
       );
 
@@ -311,6 +322,7 @@ return baseclass.extend({
         _("Confirm Upload"),
       );
       const updateGoState = () => {
+        if (busy) return;
         goBtn.disabled = !check.ok || !fields.valid();
       };
       updateGoState();
@@ -327,13 +339,19 @@ return baseclass.extend({
       );
 
       goBtn.addEventListener("click", () => {
+        busy = true;
         goBtn.disabled = true;
+        removeBtn.disabled = true;
+        setFieldsDisabled(true);
         showProgress();
         setProgress(0);
         const meta = fields.value();
         cfg
           .upload(file, meta, setProgress)
           .catch((err) => {
+            busy = false;
+            removeBtn.disabled = false;
+            setFieldsDisabled(false);
             hideProgress();
             updateGoState();
             ui.addNotification(
@@ -356,8 +374,8 @@ return baseclass.extend({
         "div",
         {
           style:
-            "margin-top:0.5em;padding-top:0.6em;" +
-            "border-top:1px solid var(--hairline);display:flex;" +
+            "margin-bottom:0.5em;padding-bottom:0.6em;" +
+            "border-bottom:1px solid var(--hairline);display:flex;" +
             "flex-direction:column;gap:0.6em;",
         },
         [fileLine, errEl, fieldsRow, noteEl, progressWrap].filter(Boolean),

--- a/htdocs/luci-static/resources/utils/asset-upload.js
+++ b/htdocs/luci-static/resources/utils/asset-upload.js
@@ -93,7 +93,12 @@ return baseclass.extend({
   //   rows: [{ preview, name, badge, size, onDelete() }],  // badge: plain text or falsy
   //   bar: { hint, sub, accept },
   //   checkFile(file) -> { ok, err },
-  //   form: { fields(file) -> { el, value(), valid() }, note },
+  //   form: {
+  //     fields(file) -> {
+  //       rows: [{label, control}],   // rendered as cbi-value label/field rows
+  //       value(), valid(), setDisabled(bool),   // bool reaches every control
+  //     },
+  //   },
   //   upload(file, meta, onProgress) -> Promise,   // caller composes
   //                                                // uploadToRouter + RPC
   // }
@@ -244,7 +249,7 @@ return baseclass.extend({
         {
           style:
             "display:none;height:5px;border-radius:999px;" +
-            "background:var(--hairline);overflow:hidden;",
+            "background:var(--hairline);overflow:hidden;margin-top:0.6em;",
         },
         [progressBar],
       );
@@ -260,71 +265,40 @@ return baseclass.extend({
       };
 
       let busy = false;
-      const setFieldsDisabled = (disabled) => {
-        fields.el
-          .querySelectorAll("input, select, textarea")
-          .forEach((el) => {
-            el.disabled = disabled;
-          });
-      };
 
-      const removeBtn = E(
+      const cancelBtn = E(
         "button",
-        {
-          type: "button",
-          class: "cbi-button",
-          title: _("Remove file"),
-          style: "padding:0.15em 0.5em;line-height:1;",
-          click: renderBar,
-        },
-        "✕",
+        { type: "button", class: "cbi-button", click: renderBar },
+        _("Cancel"),
       );
 
-      const fileLine = E(
-        "div",
-        { style: "display:flex;align-items:center;gap:0.55em;" },
-        [
-          E(
-            "span",
-            {
-              style:
-                "width:26px;height:26px;border-radius:0.4em;flex:0 0 auto;" +
-                "background:var(--brand);color:var(--on-brand);" +
-                "display:flex;align-items:center;justify-content:center;" +
-                "font-size:0.68em;font-weight:800;",
-            },
-            extOf(file.name).toUpperCase().slice(0, 4),
-          ),
-          E(
-            "span",
-            {
-              style:
-                "font-weight:700;font-size:0.93em;word-break:break-all;",
-            },
-            file.name,
-          ),
-          E(
-            "span",
-            {
-              style:
-                "color:var(--text-muted);font-size:0.85em;white-space:nowrap;",
-            },
-            formatSize(file.size),
-          ),
-          E("span", { style: "flex:1;" }, ""),
-          removeBtn,
-        ],
-      );
+      const fileSummary = E("div", { style: "margin-bottom:0.6em;" }, [
+        E("strong", { style: "word-break:break-all;" }, file.name),
+        " · " + formatSize(file.size),
+      ]);
 
       const errEl = check.ok
         ? null
         : E(
             "p",
             {
-              style: "color:var(--danger);font-weight:600;font-size:0.9em;margin:0;",
+              style:
+                "color:var(--danger);font-weight:600;font-size:0.9em;" +
+                "margin:0 0 0.6em;",
             },
             check.err,
           );
+
+      const rowsEl = E(
+        "div",
+        { style: "margin-bottom:0.6em;" },
+        fields.rows.map((row) =>
+          E("div", { class: "cbi-value" }, [
+            E("label", { class: "cbi-value-title" }, row.label),
+            E("div", { class: "cbi-value-field" }, row.control),
+          ]),
+        ),
+      );
 
       const goBtn = E(
         "button",
@@ -336,23 +310,20 @@ return baseclass.extend({
         goBtn.disabled = !check.ok || !fields.valid();
       };
       updateGoState();
-      fields.el.addEventListener("input", updateGoState);
-      fields.el.addEventListener("change", updateGoState);
+      rowsEl.addEventListener("input", updateGoState);
+      rowsEl.addEventListener("change", updateGoState);
 
-      const fieldsRow = E(
-        "div",
-        {
-          style:
-            "display:flex;gap:0.6em;flex-wrap:wrap;align-items:center;",
-        },
-        [fields.el, E("span", { style: "flex:1;" }, ""), goBtn],
-      );
+      const actionsRow = E("div", { class: "right" }, [
+        cancelBtn,
+        " ",
+        goBtn,
+      ]);
 
       goBtn.addEventListener("click", () => {
         busy = true;
         goBtn.disabled = true;
-        removeBtn.disabled = true;
-        setFieldsDisabled(true);
+        cancelBtn.disabled = true;
+        fields.setDisabled(true);
         showProgress();
         setProgress(0);
         const meta = fields.value();
@@ -360,8 +331,8 @@ return baseclass.extend({
           .upload(file, meta, setProgress)
           .catch((err) => {
             busy = false;
-            removeBtn.disabled = false;
-            setFieldsDisabled(false);
+            cancelBtn.disabled = false;
+            fields.setDisabled(false);
             hideProgress();
             updateGoState();
             ui.addNotification(
@@ -372,23 +343,14 @@ return baseclass.extend({
           });
       });
 
-      const noteEl = cfg.form.note
-        ? E(
-            "div",
-            { style: "font-size:0.82em;color:var(--text-muted);opacity:0.8;" },
-            cfg.form.note,
-          )
-        : null;
-
       return E(
         "div",
         {
           style:
             "margin-bottom:0.5em;padding-bottom:0.6em;" +
-            "border-bottom:1px solid var(--hairline);display:flex;" +
-            "flex-direction:column;gap:0.6em;",
+            "border-bottom:1px solid var(--hairline);",
         },
-        [fileLine, errEl, fieldsRow, noteEl, progressWrap].filter(Boolean),
+        [fileSummary, errEl, rowsEl, actionsRow, progressWrap].filter(Boolean),
       );
     };
 

--- a/htdocs/luci-static/resources/utils/asset-upload.js
+++ b/htdocs/luci-static/resources/utils/asset-upload.js
@@ -10,7 +10,12 @@
 
 const MAX_UPLOAD = 8 * 1024 * 1024;
 
-const formatSize = (bytes) => (bytes / 1048576).toFixed(1) + " MB";
+const formatSize = (bytes) =>
+  bytes >= 1048576
+    ? (bytes / 1048576).toFixed(1) + " MB"
+    : Math.round(bytes / 1024) + " KB";
+
+const extOf = (name) => (name.match(/\.([a-z0-9]+)$/i)?.[1] || "").toLowerCase();
 
 return baseclass.extend({
   MAX_UPLOAD,
@@ -191,6 +196,354 @@ return baseclass.extend({
         el.style.display = "none";
       },
     };
+  },
+
+  // Composite "asset manager": a table (preview | name | badge | size | ✕)
+  // sitting on a dock that shows either the slim upload bar, the in-place
+  // confirm form, or a progress row -- never more than one at a time. Both
+  // custom-fonts and the brand asset library render through this; the only
+  // per-kind knowledge lives in the caller's row/bar/form/checkFile/upload
+  // callbacks. See prototype v3 variant A (font-upload-proto.html) for the
+  // interaction blueprint this replicates.
+  //
+  // cfg = {
+  //   badgeHeader,                 // _("Slot") or _("Type")
+  //   emptyText,
+  //   rows: [{ preview, name, badge: { label, tone }, size, onDelete() }],
+  //   bar: { hint, sub, accept },
+  //   checkFile(file) -> { ok, err },
+  //   form: { fields(file) -> { el, value(), valid() }, note },
+  //   upload(file, meta, onProgress) -> Promise,   // caller composes
+  //                                                // uploadToRouter + RPC
+  // }
+  createAssetManager(cfg) {
+    const rows = cfg.rows || [];
+    const th = (width) =>
+      "text-align:left;font-size:0.72em;color:var(--text-muted);" +
+      "font-weight:600;letter-spacing:0.03em;padding:0.4em 0.75em;" +
+      "background:var(--surface-sunken);border-bottom:1px solid var(--hairline);" +
+      (width ? "width:" + width + "px;" : "");
+    const td =
+      "padding:0.45em 0.75em;border-bottom:1px solid var(--hairline);" +
+      "vertical-align:middle;";
+    const badgeStyle = (tone) =>
+      "display:inline-block;font-size:0.68em;font-weight:700;" +
+      "letter-spacing:0.03em;padding:0.08em 0.55em;border-radius:999px;" +
+      "white-space:nowrap;" +
+      (tone === "brand"
+        ? "background:var(--brand-subtle);color:var(--brand);"
+        : "background:var(--surface-sunken);color:var(--text-muted);" +
+          "border:1px solid var(--hairline);");
+
+    const shell = E("div", {
+      style:
+        "border:1px solid var(--hairline);border-radius:var(--radius-base);" +
+        "overflow:hidden;",
+    });
+
+    if (rows.length) {
+      shell.appendChild(
+        E(
+          "table",
+          { style: "width:100%;border-collapse:collapse;font-size:0.9em;" },
+          [
+            E("thead", {}, [
+              E("tr", {}, [
+                E("th", { style: th(40) }, ""),
+                E("th", { style: th() }, _("Name")),
+                E("th", { style: th(76) }, cfg.badgeHeader),
+                E("th", { style: th(84) }, _("Size")),
+                E("th", { style: th(40) }, ""),
+              ]),
+            ]),
+            E(
+              "tbody",
+              {},
+              rows.map((row) =>
+                E("tr", {}, [
+                  E("td", { style: td }, row.preview),
+                  E(
+                    "td",
+                    { style: td + "font-weight:600;word-break:break-all;" },
+                    row.name,
+                  ),
+                  E(
+                    "td",
+                    { style: td },
+                    row.badge
+                      ? E(
+                          "span",
+                          { style: badgeStyle(row.badge.tone) },
+                          row.badge.label,
+                        )
+                      : "",
+                  ),
+                  E(
+                    "td",
+                    {
+                      style:
+                        td +
+                        "color:var(--text-muted);font-variant-numeric:tabular-nums;" +
+                        "white-space:nowrap;",
+                    },
+                    formatSize(row.size || 0),
+                  ),
+                  E(
+                    "td",
+                    { style: td },
+                    E(
+                      "button",
+                      {
+                        type: "button",
+                        class: "cbi-button",
+                        title: _("Delete"),
+                        style: "padding:0.15em 0.5em;line-height:1;",
+                        click: row.onDelete,
+                      },
+                      "✕",
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ],
+        ),
+      );
+    } else {
+      shell.appendChild(
+        E(
+          "div",
+          {
+            style:
+              "padding:0.75em 0.9em;color:var(--text-muted);font-size:0.9em;" +
+              "border-bottom:1px solid var(--hairline);",
+          },
+          cfg.emptyText,
+        ),
+      );
+    }
+
+    const dock = E("div", {});
+    shell.appendChild(dock);
+
+    const clearDock = () => {
+      while (dock.firstChild) dock.firstChild.remove();
+    };
+
+    const renderBar = () => {
+      clearDock();
+      const input = E("input", {
+        type: "file",
+        style: "display:none;",
+        accept: (cfg.bar && cfg.bar.accept) || "",
+      });
+      input.addEventListener("change", () => {
+        const file = input.files && input.files[0];
+        input.value = "";
+        if (file) onFile(file);
+      });
+
+      const bar = E(
+        "button",
+        {
+          type: "button",
+          style:
+            "display:flex;align-items:center;gap:0.6em;width:100%;" +
+            "padding:0.6em 0.9em;background:var(--surface-sunken);" +
+            "border:0;border-top:1px solid var(--hairline);text-align:left;" +
+            "cursor:pointer;color:var(--text);font:inherit;",
+          click: () => input.click(),
+          dragover: (e) => {
+            e.preventDefault();
+            bar.style.background = "var(--brand-subtle)";
+          },
+          dragleave: () => {
+            bar.style.background = "var(--surface-sunken)";
+          },
+          drop: (e) => {
+            e.preventDefault();
+            bar.style.background = "var(--surface-sunken)";
+            const file = e.dataTransfer && e.dataTransfer.files[0];
+            if (file) onFile(file);
+          },
+        },
+        [
+          E(
+            "span",
+            {
+              style:
+                "width:26px;height:26px;border-radius:0.4em;flex:0 0 auto;" +
+                "background:var(--brand-subtle);color:var(--brand);" +
+                "display:flex;align-items:center;justify-content:center;" +
+                "font-weight:800;",
+            },
+            "⬆",
+          ),
+          E("strong", { style: "font-size:0.93em;" }, cfg.bar.hint),
+          E("span", { style: "flex:1;" }, ""),
+          E(
+            "span",
+            { style: "color:var(--text-muted);font-size:0.89em;" },
+            cfg.bar.sub || "",
+          ),
+          input,
+        ],
+      );
+
+      dock.appendChild(bar);
+    };
+
+    const buildForm = (file, check) => {
+      const fields = cfg.form.fields(file);
+
+      const progressBar = E("div", {
+        style:
+          "height:100%;width:0%;transition:width 0.12s linear;" +
+          "background:var(--brand);border-radius:999px;",
+      });
+      const progressWrap = E(
+        "div",
+        {
+          style:
+            "display:none;height:5px;border-radius:999px;" +
+            "background:var(--hairline);overflow:hidden;",
+        },
+        [progressBar],
+      );
+      const setProgress = (p) => {
+        progressBar.style.width = p + "%";
+      };
+      const showProgress = () => {
+        progressWrap.style.display = "block";
+      };
+      const hideProgress = () => {
+        progressWrap.style.display = "none";
+        setProgress(0);
+      };
+
+      const fileLine = E(
+        "div",
+        { style: "display:flex;align-items:center;gap:0.55em;" },
+        [
+          E(
+            "span",
+            {
+              style:
+                "width:26px;height:26px;border-radius:0.4em;flex:0 0 auto;" +
+                "background:var(--brand);color:var(--on-brand);" +
+                "display:flex;align-items:center;justify-content:center;" +
+                "font-size:0.68em;font-weight:800;",
+            },
+            extOf(file.name).toUpperCase().slice(0, 4),
+          ),
+          E(
+            "span",
+            {
+              style:
+                "font-weight:700;font-size:0.93em;word-break:break-all;",
+            },
+            file.name,
+          ),
+          E(
+            "span",
+            {
+              style:
+                "color:var(--text-muted);font-size:0.85em;white-space:nowrap;",
+            },
+            formatSize(file.size),
+          ),
+          E("span", { style: "flex:1;" }, ""),
+          E(
+            "button",
+            {
+              type: "button",
+              class: "cbi-button",
+              title: _("Remove file"),
+              style: "padding:0.15em 0.5em;line-height:1;",
+              click: renderBar,
+            },
+            "✕",
+          ),
+        ],
+      );
+
+      const errEl = check.ok
+        ? null
+        : E(
+            "p",
+            {
+              style: "color:var(--danger);font-weight:600;font-size:0.9em;margin:0;",
+            },
+            check.err,
+          );
+
+      const goBtn = E(
+        "button",
+        { type: "button", class: "cbi-button cbi-button-positive" },
+        _("Confirm Upload"),
+      );
+      const updateGoState = () => {
+        goBtn.disabled = !check.ok || !fields.valid();
+      };
+      updateGoState();
+      fields.el.addEventListener("input", updateGoState);
+      fields.el.addEventListener("change", updateGoState);
+
+      const fieldsRow = E(
+        "div",
+        {
+          style:
+            "display:flex;gap:0.6em;flex-wrap:wrap;align-items:center;",
+        },
+        [fields.el, E("span", { style: "flex:1;" }, ""), goBtn],
+      );
+
+      goBtn.addEventListener("click", () => {
+        goBtn.disabled = true;
+        showProgress();
+        setProgress(0);
+        const meta = fields.value();
+        cfg
+          .upload(file, meta, setProgress)
+          .catch((err) => {
+            hideProgress();
+            updateGoState();
+            ui.addNotification(
+              null,
+              E("p", _("Upload failed: %s").format(err.message)),
+              "error",
+            );
+          });
+      });
+
+      const noteEl = cfg.form.note
+        ? E(
+            "div",
+            { style: "font-size:0.82em;color:var(--text-muted);opacity:0.8;" },
+            cfg.form.note,
+          )
+        : null;
+
+      return E(
+        "div",
+        {
+          style:
+            "padding:0.75em 0.9em;background:var(--surface-sunken);" +
+            "border-top:1px solid var(--hairline);display:flex;" +
+            "flex-direction:column;gap:0.6em;",
+        },
+        [fileLine, errEl, fieldsRow, noteEl, progressWrap].filter(Boolean),
+      );
+    };
+
+    const onFile = (file) => {
+      const check = cfg.checkFile(file);
+      clearDock();
+      dock.appendChild(buildForm(file, check));
+    };
+
+    renderBar();
+    return shell;
   },
 
   confirmDelete(opts) {

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2085,21 +2085,21 @@ return view.extend({
     so.rmempty = false;
     so.render = renderContainerMaxWidthControl;
 
-    const fontLibrarySection = s.taboption(
+    const fontSection = s.taboption(
       "layout_typography",
       form.SectionValue,
-      "_font_library",
+      "_font_settings",
       form.NamedSection,
       "theme",
       "aurora",
-      _("Font Library"),
+      _("Typography"),
       _(
-        "Keep custom font files as small as possible, as they are stored in the router's limited flash storage.",
+        "Sans-serif and monospace typefaces used across the theme. Webfonts are downloaded once from pinned, checksum-verified sources and served locally; pages never load fonts from the internet.",
       ),
     );
-    const fontLibrarySubsection = fontLibrarySection.subsection;
+    const fontSubsection = fontSection.subsection;
 
-    const fontTableSo = fontLibrarySubsection.option(
+    const fontTableSo = fontSubsection.option(
       form.DummyValue,
       "_font_table",
       " ",
@@ -2228,22 +2228,17 @@ return view.extend({
             }),
       });
 
-      return fontManager;
+      return E("div", {}, [
+        fontManager,
+        E(
+          "p",
+          { style: "opacity:0.6;font-size:0.9em;margin:0.35em 0 0;" },
+          _(
+            "Keep custom font files as small as possible, as they are stored in the router's limited flash storage.",
+          ),
+        ),
+      ]);
     };
-
-    const fontSection = s.taboption(
-      "layout_typography",
-      form.SectionValue,
-      "_font_settings",
-      form.NamedSection,
-      "theme",
-      "aurora",
-      _("Typography"),
-      _(
-        "Sans-serif and monospace typefaces used across the theme. Webfonts are downloaded once from pinned, checksum-verified sources and served locally; pages never load fonts from the internet.",
-      ),
-    );
-    const fontSubsection = fontSection.subsection;
 
     const fontSlotOpts = {};
 

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -1506,6 +1506,10 @@ return view.extend({
       const themeConfig = readThemeConfigFromUci();
       const iconsData = {
         icons: Array.isArray(initData?.icons) ? initData.icons : [],
+        icon_sizes:
+          initData?.icon_sizes && typeof initData.icon_sizes === "object"
+            ? initData.icon_sizes
+            : {},
       };
       if (Array.isArray(initData?.icons))
         _iconsPromise = Promise.resolve(iconsData);
@@ -2169,139 +2173,7 @@ return view.extend({
           .join(" ");
       };
 
-      const confirmWrap = E("div", {});
-
-      const buildConfirmCard = (file) => {
-        while (confirmWrap.firstChild) confirmWrap.firstChild.remove();
-
-        const check = assetUpload.checkFile(file, { exts: ["woff2"] });
-
-        const familyInput = E("input", {
-          type: "text",
-          class: "cbi-input-text",
-          placeholder: _("Font family name, e.g. MiSans"),
-          value: familyFromFilename(file.name),
-        });
-        const slotSelect = E("select", { class: "cbi-input-select" }, [
-          E("option", { value: "sans" }, _("Sans-Serif")),
-          E("option", { value: "mono" }, _("Monospace")),
-        ]);
-        const progress = assetUpload.createProgressRow();
-
-        const goBtn = E(
-          "button",
-          {
-            class: "cbi-button cbi-button-positive",
-            disabled: check.ok ? null : "",
-            click: ui.createHandlerFn(viewCtx, () => {
-              const family = familyInput.value.trim();
-              if (!family) {
-                ui.addNotification(
-                  null,
-                  E("p", _("Font family name, e.g. MiSans")),
-                  "warning",
-                );
-                return Promise.resolve();
-              }
-              dropzone.setBusy(true);
-              progress.show();
-              progress.set(0, file.name);
-              return assetUpload
-                .uploadToRouter({
-                  tmpPath: FONT_TMP_PATH,
-                  file,
-                  onProgress: (p) => progress.set(p),
-                })
-                .then(() =>
-                  L.resolveDefault(
-                    callUploadFont(slotSelect.value, family),
-                    {},
-                  ),
-                )
-                .then((ret) => {
-                  if (ret?.result === 0) window.location.reload();
-                  else throw new Error(ret?.error || _("Unknown"));
-                })
-                .catch((err) => {
-                  dropzone.setBusy(false);
-                  progress.hide();
-                  ui.addNotification(
-                    null,
-                    E("p", _("Upload failed: %s").format(err.message)),
-                    "error",
-                  );
-                });
-            }),
-          },
-          _("Confirm Upload"),
-        );
-
-        confirmWrap.appendChild(
-          E(
-            "div",
-            {
-              style:
-                "border:1px solid var(--hairline);border-left:3px solid var(--brand);border-radius:0.5em;padding:0.75em 0.875em;margin-top:0.6em;",
-            },
-            [
-              E(
-                "div",
-                {
-                  style:
-                    "display:flex;justify-content:space-between;align-items:center;gap:0.6em;margin-bottom:0.6em;",
-                },
-                [
-                  E("strong", { style: "word-break:break-all;" }, file.name),
-                  E(
-                    "span",
-                    { style: "opacity:0.6;white-space:nowrap;" },
-                    assetUpload.formatSize(file.size),
-                  ),
-                  E(
-                    "button",
-                    {
-                      class: "cbi-button",
-                      title: _("Remove file"),
-                      click: () => {
-                        while (confirmWrap.firstChild)
-                          confirmWrap.firstChild.remove();
-                      },
-                    },
-                    "✕",
-                  ),
-                ],
-              ),
-              check.ok
-                ? ""
-                : E(
-                    "p",
-                    { style: "color:var(--danger);font-weight:600;" },
-                    check.err,
-                  ),
-              E("div", { class: "cbi-value" }, [
-                E("label", { class: "cbi-value-title" }, _("Family")),
-                E("div", { class: "cbi-value-field" }, familyInput),
-              ]),
-              E("div", { class: "cbi-value" }, [
-                E("label", { class: "cbi-value-title" }, _("Slot")),
-                E("div", { class: "cbi-value-field" }, slotSelect),
-              ]),
-              progress.el,
-              E("div", { class: "right" }, goBtn),
-            ],
-          ),
-        );
-      };
-
-      const dropzone = assetUpload.createDropzone({
-        hint: _("Drop a .woff2 font here, or click to browse"),
-        sub: _("Only .woff2 files up to 8MB are accepted."),
-        accept: ".woff2",
-        compact: true,
-        onFile: buildConfirmCard,
-      });
-
-      const removeRow = (font) =>
+      const removeFont = (font) =>
         assetUpload.confirmDelete({
           title: _("Delete Custom Font"),
           message: _(
@@ -2326,30 +2198,88 @@ return view.extend({
           });
         });
 
-      const rows = customs.map((font) =>
-        E("li", {}, [
-          E("code", {}, font.family),
-          " — " +
-            (font.slot === "sans" ? _("Sans-Serif") : _("Monospace")) +
-            " ",
-          E(
-            "button",
+      const fontManager = assetUpload.createAssetManager({
+        badgeHeader: _("Slot"),
+        emptyText: _("No custom fonts uploaded."),
+        rows: customs.map((font) => ({
+          preview: E(
+            "div",
             {
-              class: "cbi-button cbi-button-remove",
-              click: ui.createHandlerFn(viewCtx, () => removeRow(font)),
+              style:
+                "width:34px;height:34px;border-radius:0.4em;" +
+                "background:var(--surface-sunken);border:1px solid var(--hairline);" +
+                "display:flex;align-items:center;justify-content:center;" +
+                "font-weight:700;font-size:0.95em;" +
+                "font-family:" +
+                (font.slot === "mono" ? "var(--font-mono)" : "var(--font-sans)") +
+                ";",
             },
-            _("Delete"),
+            "Aa",
           ),
-        ]),
-      );
+          name: font.family,
+          badge: {
+            label: font.slot === "sans" ? _("Sans-Serif") : _("Monospace"),
+            tone: font.slot === "sans" ? "brand" : "neutral",
+          },
+          size: font.size || 0,
+          onDelete: ui.createHandlerFn(viewCtx, () => removeFont(font)),
+        })),
+        bar: {
+          hint: _("Drop a .woff2 font here, or click to browse"),
+          sub: _("Only .woff2 files up to 8MB are accepted."),
+          accept: ".woff2",
+        },
+        checkFile: (file) => assetUpload.checkFile(file, { exts: ["woff2"] }),
+        form: {
+          fields: (file) => {
+            const nameInput = E("input", {
+              type: "text",
+              class: "cbi-input-text",
+              style: "flex:1;min-width:11em;",
+              placeholder: _("Font family name, e.g. MiSans"),
+              value: familyFromFilename(file.name),
+            });
+            const slotSelect = E(
+              "select",
+              { class: "cbi-input-select", style: "max-width:10em;" },
+              [
+                E("option", { value: "sans" }, _("Sans-Serif")),
+                E("option", { value: "mono" }, _("Monospace")),
+              ],
+            );
+            return {
+              el: E(
+                "div",
+                {
+                  style:
+                    "display:flex;gap:0.6em;flex-wrap:wrap;align-items:center;",
+                },
+                [nameInput, slotSelect],
+              ),
+              value: () => ({
+                name: nameInput.value.trim(),
+                slot: slotSelect.value,
+              }),
+              valid: () => !!nameInput.value.trim(),
+            };
+          },
+        },
+        upload: (file, meta, onProgress) =>
+          assetUpload
+            .uploadToRouter({ tmpPath: FONT_TMP_PATH, file, onProgress })
+            .then(() =>
+              L.resolveDefault(callUploadFont(meta.slot, meta.name), {}),
+            )
+            .then((ret) => {
+              if (ret?.result === 0) window.location.reload();
+              else throw new Error(ret?.error || _("Unknown"));
+            }),
+      });
 
       return E("div", { class: "cbi-value" }, [
         E("label", { class: "cbi-value-title" }, _("Custom Fonts")),
         E("div", { class: "cbi-value-field" }, [
-          rows.length
-            ? E("ul", { style: "margin:0 0 0.5em 0;" }, rows)
-            : E("p", { style: "opacity:0.6;" }, _("No custom fonts uploaded.")),
-          dropzone,
+          fontManager,
           E(
             "p",
             { style: "opacity:0.6;font-size:0.9em;margin:0.35em 0 0;" },
@@ -2357,7 +2287,6 @@ return view.extend({
               "Keep custom font files as small as possible, as they are stored in the router's limited flash storage.",
             ),
           ),
-          confirmWrap,
         ]),
       ]);
     };
@@ -2519,74 +2448,26 @@ return view.extend({
     );
     assetTableSo.load = () => getIconsOnce();
     assetTableSo.cfgvalue = (section_id, data) => data?.icons || [];
+    const ICON_EXTS = ["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"];
+    const iconExtOf = (name) =>
+      (name.match(/\.([a-z0-9]+)$/i)?.[1] || "").toLowerCase();
+
     assetTableSo.render = function (option_index, section_id, in_table) {
       return this.load(section_id).then((data) => {
         const icons = this.cfgvalue(section_id, data);
+        const sizes = data?.icon_sizes || {};
         const tmpPath = "/tmp/aurora_icon.tmp";
-        const progress = assetUpload.createProgressRow();
-
-        const uploadFile = (file) => {
-          const check = assetUpload.checkFile(file, {
-            exts: ["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"],
-          });
-          if (!check.ok) {
-            ui.addNotification(null, E("p", check.err), "error");
-            return;
-          }
-          dropzone.setBusy(true);
-          progress.show();
-          progress.set(0, file.name);
-
-          assetUpload
-            .uploadToRouter({
-              tmpPath,
-              file,
-              onProgress: (p) => progress.set(p),
-            })
-            .then(() => L.resolveDefault(callUploadIcon(file.name), {}))
-            .then((ret) => {
-              if (ret?.result === 0) {
-                if (/^login-bg\./i.test(file.name)) {
-                  localStorage.setItem("aurora.pending_bg", file.name);
-                }
-                window.location.reload();
-              } else {
-                throw new Error(ret?.error || _("Unknown"));
-              }
-            })
-            .catch((err) => {
-              dropzone.setBusy(false);
-              progress.hide();
-              ui.addNotification(
-                null,
-                E("p", _("Upload failed: %s").format(err.message)),
-                "error",
-              );
-            });
-        };
-
-        const dropzone = assetUpload.createDropzone({
-          hint: _("Drop image asset here, or click to browse"),
-          sub: _("JPG · PNG · WebP · AVIF · SVG · GIF · ICO"),
-          accept: "image/*,.svg,.ico",
-          onFile: uploadFile,
-        });
 
         const idleCallback = window.requestIdleCallback
           ? (fn) => window.requestIdleCallback(fn, { timeout: 2000 })
           : (fn) => setTimeout(fn, 100);
 
-        const makeRow = (icon) => {
+        const makePreview = (icon) => {
           const placeholder = E("div", {
             style:
-              "width:40px;height:40px;border-radius:4px;background:var(--surface-sunken);",
+              "width:34px;height:34px;border-radius:0.4em;" +
+              "background:var(--surface-sunken);border:1px solid var(--hairline);",
           });
-          const previewCell = E(
-            "td",
-            { class: "td", style: "width:56px;" },
-            placeholder,
-          );
-
           idleCallback(() => {
             generateLqip("/luci-static/aurora/images/" + icon).then(
               (dataUrl) => {
@@ -2595,86 +2476,118 @@ return view.extend({
                   E("img", {
                     src: dataUrl,
                     style:
-                      "width:40px;height:40px;object-fit:contain;border-radius:4px;display:block;",
+                      "width:34px;height:34px;object-fit:cover;" +
+                      "border-radius:0.4em;display:block;",
                     alt: "",
                   }),
                 );
               },
             );
           });
-
-          const deleteBtn = E(
-            "button",
-            {
-              class: "cbi-button cbi-button-remove",
-              click: ui.createHandlerFn(this, () =>
-                assetUpload
-                  .confirmDelete({
-                    title: _("Delete Brand Asset"),
-                    message: _(
-                      "Delete '%s' from /www/luci-static/aurora/images/? Theme settings that reference it may need updating.",
-                    ).format(icon),
-                  })
-                  .then((confirmed) => {
-                    if (!confirmed) return;
-                    ui.showModal(_("Deleting…"), [
-                      E("p", { class: "spinning" }, _("Please wait…")),
-                    ]);
-                    return L.resolveDefault(callRemoveIcon(icon), {}).then(
-                      (ret) => {
-                        ui.hideModal();
-                        if (ret?.result === 0) {
-                          ui.addNotification(
-                            null,
-                            E("p", _("Deleted: %s").format(icon)),
-                          );
-                          window.location.reload();
-                        } else {
-                          ui.addNotification(
-                            null,
-                            E(
-                              "p",
-                              _("Failed to delete: %s").format(
-                                ret?.error || "Unknown",
-                              ),
-                            ),
-                            "error",
-                          );
-                        }
-                      },
-                    );
-                  }),
-              ),
-            },
-            _("Delete"),
-          );
-
-          return E("tr", { class: "tr" }, [
-            previewCell,
-            E("td", { class: "td", style: "font-family:monospace;" }, icon),
-            E("td", { class: "td center" }, deleteBtn),
-          ]);
+          return placeholder;
         };
 
-        const tableOrEmpty =
-          icons.length === 0
-            ? E("div", { style: "padding:0.5em 0;" }, [
-                E("em", {}, _("No brand assets uploaded yet.")),
-              ])
-            : E("table", { class: "table" }, [
-                E("tr", { class: "tr table-titles" }, [
-                  E("th", { class: "th", style: "width:56px;" }, _("Preview")),
-                  E("th", { class: "th" }, _("Asset Filename")),
-                  E("th", { class: "th center" }, _("Actions")),
-                ]),
-                ...icons.map(makeRow),
-              ]);
+        const removeIcon = (icon) =>
+          assetUpload.confirmDelete({
+            title: _("Delete Brand Asset"),
+            message: _(
+              "Delete '%s' from /www/luci-static/aurora/images/? Theme settings that reference it may need updating.",
+            ).format(icon),
+          }).then((confirmed) => {
+            if (!confirmed) return;
+            ui.showModal(_("Deleting…"), [
+              E("p", { class: "spinning" }, _("Please wait…")),
+            ]);
+            return L.resolveDefault(callRemoveIcon(icon), {}).then((ret) => {
+              ui.hideModal();
+              if (ret?.result === 0) {
+                ui.addNotification(
+                  null,
+                  E("p", _("Deleted: %s").format(icon)),
+                );
+                window.location.reload();
+              } else {
+                ui.addNotification(
+                  null,
+                  E(
+                    "p",
+                    _("Failed to delete: %s").format(
+                      ret?.error || "Unknown",
+                    ),
+                  ),
+                  "error",
+                );
+              }
+            });
+          });
 
-        return E("div", { "data-name": this.option }, [
-          E("div", { style: "margin-bottom:0.75em;" }, dropzone),
-          progress.el,
-          tableOrEmpty,
-        ]);
+        const iconManager = assetUpload.createAssetManager({
+          badgeHeader: _("Type"),
+          emptyText: _("No brand assets uploaded yet."),
+          rows: icons.map((icon) => ({
+            preview: makePreview(icon),
+            name: icon,
+            badge: { label: iconExtOf(icon).toUpperCase(), tone: "neutral" },
+            size: sizes[icon] || 0,
+            onDelete: ui.createHandlerFn(this, () => removeIcon(icon)),
+          })),
+          bar: {
+            hint: _("Drop image asset here, or click to browse"),
+            sub: _("JPG · PNG · WebP · AVIF · SVG · GIF · ICO"),
+            accept: "image/*,.svg,.ico",
+          },
+          checkFile: (file) =>
+            assetUpload.checkFile(file, {
+              exts: ["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"],
+            }),
+          form: {
+            fields: (file) => {
+              const nameInput = E("input", {
+                type: "text",
+                class: "cbi-input-text",
+                style: "flex:1;min-width:11em;",
+                placeholder: _("Filename (with extension)"),
+                value: file.name,
+              });
+              return {
+                el: E(
+                  "div",
+                  {
+                    style:
+                      "display:flex;gap:0.6em;flex-wrap:wrap;align-items:center;",
+                  },
+                  [nameInput],
+                ),
+                value: () => ({ name: nameInput.value.trim() }),
+                valid: () => {
+                  const v = nameInput.value.trim();
+                  return (
+                    !!v && !v.includes("/") && ICON_EXTS.includes(iconExtOf(v))
+                  );
+                },
+              };
+            },
+            note: _(
+              "Name it login-bg.* to use it as the login page background.",
+            ),
+          },
+          upload: (file, meta, onProgress) =>
+            assetUpload
+              .uploadToRouter({ tmpPath, file, onProgress })
+              .then(() => L.resolveDefault(callUploadIcon(meta.name), {}))
+              .then((ret) => {
+                if (ret?.result === 0) {
+                  if (/^login-bg\./i.test(meta.name)) {
+                    localStorage.setItem("aurora.pending_bg", meta.name);
+                  }
+                  window.location.reload();
+                } else {
+                  throw new Error(ret?.error || _("Unknown"));
+                }
+              }),
+        });
+
+        return E("div", { "data-name": this.option }, [iconManager]);
       });
     };
 

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2354,7 +2354,7 @@ return view.extend({
             "p",
             { style: "opacity:0.6;font-size:0.9em;margin:0.35em 0 0;" },
             _(
-              "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster.",
+              "Keep custom font files as small as possible, as they are stored in the router's limited flash storage.",
             ),
           ),
           confirmWrap,

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2188,7 +2188,14 @@ return view.extend({
         const fileInput = E("input", { type: "file", accept: ".woff2" });
 
         ui.showModal(_("Upload Custom Font"), [
-          E("p", {}, _("Only .woff2 files up to 4MB are accepted.")),
+          E("p", {}, _("Only .woff2 files up to 8MB are accepted.")),
+          E(
+            "p",
+            { style: "opacity:0.6; font-size:0.9em; margin-top:-0.3em;" },
+            _(
+              "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster.",
+            ),
+          ),
           E("div", { class: "cbi-value" }, [
             E("label", { class: "cbi-value-title" }, _("Slot")),
             E("div", { class: "cbi-value-field" }, slotSelect),

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2106,6 +2106,10 @@ return view.extend({
     );
     fontTableSo.rawhtml = false;
     fontTableSo.cfgvalue = () => "";
+    // renderWidget (not render): LuCI's renderFrame() then wraps the manager
+    // in the standard cbi-value label/field row, matching the typeface
+    // selects below. The brand-asset manager overrides render() instead --
+    // its section holds only the table, so it stays full-width.
     fontTableSo.renderWidget = () => {
       const FONT_TMP_PATH = "/tmp/aurora_font.tmp";
       const customs = fontPresetsBySlot?.custom || [];
@@ -2444,6 +2448,9 @@ return view.extend({
     assetTableSo.cfgvalue = (section_id, data) => data?.icons || [];
     const ICON_EXTS = ["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"];
 
+    // render (not renderWidget): full-width mount, no cbi-value label row --
+    // this section holds only the asset table. The font manager in the
+    // Typography section uses renderWidget for the labeled-row wrapper.
     assetTableSo.render = function (option_index, section_id, in_table) {
       return this.load(section_id).then((data) => {
         const icons = this.cfgvalue(section_id, data);

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2102,11 +2102,11 @@ return view.extend({
     const fontTableSo = fontSubsection.option(
       form.DummyValue,
       "_font_table",
-      " ",
+      _("Custom Fonts"),
     );
     fontTableSo.rawhtml = false;
     fontTableSo.cfgvalue = () => "";
-    fontTableSo.render = () => {
+    fontTableSo.renderWidget = () => {
       const FONT_TMP_PATH = "/tmp/aurora_font.tmp";
       const customs = fontPresetsBySlot?.custom || [];
 

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2217,10 +2217,7 @@ return view.extend({
             "Aa",
           ),
           name: font.family,
-          badge: {
-            label: font.slot === "sans" ? _("Sans-Serif") : _("Monospace"),
-            tone: font.slot === "sans" ? "brand" : "neutral",
-          },
+          badge: font.slot === "sans" ? _("Sans-Serif") : _("Monospace"),
           size: font.size || 0,
           onDelete: ui.createHandlerFn(viewCtx, () => removeFont(font)),
         })),
@@ -2525,7 +2522,7 @@ return view.extend({
           rows: icons.map((icon) => ({
             preview: makePreview(icon),
             name: icon,
-            badge: { label: assetUpload.extOf(icon).toUpperCase(), tone: "neutral" },
+            badge: assetUpload.extOf(icon).toUpperCase(),
             size: sizes[icon] || 0,
             onDelete: ui.createHandlerFn(this, () => removeIcon(icon)),
           })),

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -6,6 +6,7 @@
 "require ui";
 "require fs";
 "require utils.version-api";
+"require utils.asset-upload as assetUpload";
 
 const CONFIG_IMPORT_PATH = "/tmp/aurora_config_import.tmp";
 
@@ -2150,120 +2151,187 @@ return view.extend({
       const FONT_TMP_PATH = "/tmp/aurora_font.tmp";
       const customs = fontPresetsBySlot?.custom || [];
 
-      const uploadFont = (slot, family, file) =>
-        new Promise((resolve, reject) => {
-          const xhr = new XMLHttpRequest();
-          xhr.addEventListener("load", () => {
-            if (xhr.status !== 200)
-              return reject(new Error("HTTP " + xhr.status));
-            L.resolveDefault(callUploadFont(slot, family), {}).then((ret) =>
-              ret?.result === 0
-                ? resolve(ret)
-                : reject(new Error(ret?.error || _("Unknown"))),
-            );
-          });
-          xhr.addEventListener("error", () =>
-            reject(new Error(_("Upload failed"))),
+      const familyFromFilename = (name) => {
+        const stem = name.replace(/\.woff2$/i, "");
+        const parts = stem
+          .split(/[-_]+/)
+          .filter(
+            (p) =>
+              !/^(regular|bold|light|medium|semibold|thin|italic|normal|latin|\d+)$/i.test(
+                p,
+              ),
           );
-          const formData = new FormData();
-          formData.append("sessionid", rpc.getSessionID());
-          formData.append("filename", FONT_TMP_PATH);
-          formData.append("filemode", "0600");
-          formData.append("filedata", file, file.name);
-          xhr.open("POST", "/cgi-bin/cgi-upload");
-          xhr.withCredentials = true;
-          xhr.send(formData);
-        });
+        const words = parts.length ? parts : [stem];
+        return words
+          .map((w) =>
+            /^[a-z]/.test(w) ? w.charAt(0).toUpperCase() + w.slice(1) : w,
+          )
+          .join(" ");
+      };
 
-      const openUploadModal = () => {
-        const slotSelect = E("select", { class: "cbi-input-select" }, [
-          E("option", { value: "sans" }, _("Sans-Serif")),
-          E("option", { value: "mono" }, _("Monospace")),
-        ]);
+      const confirmWrap = E("div", {});
+
+      const buildConfirmCard = (file) => {
+        while (confirmWrap.firstChild) confirmWrap.firstChild.remove();
+
+        const check = assetUpload.checkFile(file, { exts: ["woff2"] });
+
         const familyInput = E("input", {
           type: "text",
           class: "cbi-input-text",
           placeholder: _("Font family name, e.g. MiSans"),
+          value: familyFromFilename(file.name),
         });
-        const fileInput = E("input", { type: "file", accept: ".woff2" });
-
-        ui.showModal(_("Upload Custom Font"), [
-          E("p", {}, _("Only .woff2 files up to 8MB are accepted.")),
-          E(
-            "p",
-            { style: "opacity:0.6; font-size:0.9em; margin-top:-0.3em;" },
-            _(
-              "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster.",
-            ),
-          ),
-          E("div", { class: "cbi-value" }, [
-            E("label", { class: "cbi-value-title" }, _("Slot")),
-            E("div", { class: "cbi-value-field" }, slotSelect),
-          ]),
-          E("div", { class: "cbi-value" }, [
-            E("label", { class: "cbi-value-title" }, _("Family")),
-            E("div", { class: "cbi-value-field" }, familyInput),
-          ]),
-          E("div", { class: "cbi-value" }, [
-            E("label", { class: "cbi-value-title" }, _("File")),
-            E("div", { class: "cbi-value-field" }, fileInput),
-          ]),
-          E("div", { class: "right" }, [
-            E(
-              "button",
-              { class: "cbi-button", click: ui.hideModal },
-              _("Cancel"),
-            ),
-            " ",
-            E(
-              "button",
-              {
-                class: "cbi-button cbi-button-positive",
-                click: ui.createHandlerFn(viewCtx, () => {
-                  const file = fileInput.files?.[0];
-                  const family = familyInput.value.trim();
-                  if (!file || !family) {
-                    ui.addNotification(
-                      null,
-                      E("p", _("Choose a .woff2 file and a family name")),
-                      "warning",
-                    );
-                    return Promise.resolve();
-                  }
-                  return uploadFont(slotSelect.value, family, file)
-                    .then(() => window.location.reload())
-                    .catch((err) =>
-                      ui.addNotification(
-                        null,
-                        E("p", _("Upload failed: %s").format(err.message)),
-                        "error",
-                      ),
-                    );
-                }),
-              },
-              _("Upload"),
-            ),
-          ]),
+        const slotSelect = E("select", { class: "cbi-input-select" }, [
+          E("option", { value: "sans" }, _("Sans-Serif")),
+          E("option", { value: "mono" }, _("Monospace")),
         ]);
+        const progress = assetUpload.createProgressRow();
+
+        const goBtn = E(
+          "button",
+          {
+            class: "cbi-button cbi-button-positive",
+            disabled: check.ok ? null : "",
+            click: ui.createHandlerFn(viewCtx, () => {
+              const family = familyInput.value.trim();
+              if (!family) {
+                ui.addNotification(
+                  null,
+                  E("p", _("Font family name, e.g. MiSans")),
+                  "warning",
+                );
+                return Promise.resolve();
+              }
+              dropzone.setBusy(true);
+              progress.show();
+              progress.set(0, file.name);
+              return assetUpload
+                .uploadToRouter({
+                  tmpPath: FONT_TMP_PATH,
+                  file,
+                  onProgress: (p) => progress.set(p),
+                })
+                .then(() =>
+                  L.resolveDefault(
+                    callUploadFont(slotSelect.value, family),
+                    {},
+                  ),
+                )
+                .then((ret) => {
+                  if (ret?.result === 0) window.location.reload();
+                  else throw new Error(ret?.error || _("Unknown"));
+                })
+                .catch((err) => {
+                  dropzone.setBusy(false);
+                  progress.hide();
+                  ui.addNotification(
+                    null,
+                    E("p", _("Upload failed: %s").format(err.message)),
+                    "error",
+                  );
+                });
+            }),
+          },
+          _("Confirm Upload"),
+        );
+
+        confirmWrap.appendChild(
+          E(
+            "div",
+            {
+              style:
+                "border:1px solid var(--hairline);border-left:3px solid var(--brand);border-radius:0.5em;padding:0.75em 0.875em;margin-top:0.6em;",
+            },
+            [
+              E(
+                "div",
+                {
+                  style:
+                    "display:flex;justify-content:space-between;align-items:center;gap:0.6em;margin-bottom:0.6em;",
+                },
+                [
+                  E("strong", { style: "word-break:break-all;" }, file.name),
+                  E(
+                    "span",
+                    { style: "opacity:0.6;white-space:nowrap;" },
+                    assetUpload.formatSize(file.size),
+                  ),
+                  E(
+                    "button",
+                    {
+                      class: "cbi-button",
+                      title: _("Remove file"),
+                      click: () => {
+                        while (confirmWrap.firstChild)
+                          confirmWrap.firstChild.remove();
+                      },
+                    },
+                    "✕",
+                  ),
+                ],
+              ),
+              check.ok
+                ? ""
+                : E(
+                    "p",
+                    { style: "color:var(--danger);font-weight:600;" },
+                    check.err,
+                  ),
+              E("div", { class: "cbi-value" }, [
+                E("label", { class: "cbi-value-title" }, _("Family")),
+                E("div", { class: "cbi-value-field" }, familyInput),
+              ]),
+              E("div", { class: "cbi-value" }, [
+                E("label", { class: "cbi-value-title" }, _("Slot")),
+                E("div", { class: "cbi-value-field" }, slotSelect),
+              ]),
+              progress.el,
+              E("div", { class: "right" }, goBtn),
+            ],
+          ),
+        );
       };
 
+      const dropzone = assetUpload.createDropzone({
+        hint: _("Drop a .woff2 font here, or click to browse"),
+        sub: _("Only .woff2 files up to 8MB are accepted."),
+        accept: ".woff2",
+        compact: true,
+        onFile: buildConfirmCard,
+      });
+
       const removeRow = (font) =>
-        L.resolveDefault(callRemoveFont(font.slot, font.name), {}).then(
-          (ret) => {
+        assetUpload.confirmDelete({
+          title: _("Delete Custom Font"),
+          message: _(
+            "Delete '%s'? The interface will fall back to the default typeface.",
+          ).format(font.family),
+        }).then((confirmed) => {
+          if (!confirmed) return;
+          return L.resolveDefault(
+            callRemoveFont(font.slot, font.name),
+            {},
+          ).then((ret) => {
             if (ret?.result === 0) window.location.reload();
             else
               ui.addNotification(
                 null,
-                E("p", _("Delete failed: %s").format(ret?.error || _("Unknown"))),
+                E(
+                  "p",
+                  _("Delete failed: %s").format(ret?.error || _("Unknown")),
+                ),
                 "error",
               );
-          },
-        );
+          });
+        });
 
       const rows = customs.map((font) =>
         E("li", {}, [
           E("code", {}, font.family),
-          " — " + (font.slot === "sans" ? _("Sans-Serif") : _("Monospace")) + " ",
+          " — " +
+            (font.slot === "sans" ? _("Sans-Serif") : _("Monospace")) +
+            " ",
           E(
             "button",
             {
@@ -2281,17 +2349,15 @@ return view.extend({
           rows.length
             ? E("ul", { style: "margin:0 0 0.5em 0;" }, rows)
             : E("p", { style: "opacity:0.6;" }, _("No custom fonts uploaded.")),
+          dropzone,
           E(
-            "button",
-            {
-              class: "cbi-button cbi-button-action",
-              click: ui.createHandlerFn(viewCtx, () => {
-                openUploadModal();
-                return Promise.resolve();
-              }),
-            },
-            _("Upload Custom Font"),
+            "p",
+            { style: "opacity:0.6;font-size:0.9em;margin:0.35em 0 0;" },
+            _(
+              "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster.",
+            ),
           ),
+          confirmWrap,
         ]),
       ]);
     };

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2533,7 +2533,7 @@ return view.extend({
           },
           checkFile: (file) =>
             assetUpload.checkFile(file, {
-              exts: ["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"],
+              exts: ICON_EXTS,
             }),
           form: {
             fields: (file) => {
@@ -2544,6 +2544,28 @@ return view.extend({
                 placeholder: _("Filename (with extension)"),
                 value: file.name,
               });
+              const collisionWarning = E(
+                "p",
+                {
+                  style:
+                    "color:var(--warning);font-size:0.9em;margin:0;" +
+                    "width:100%;display:none;",
+                },
+                "",
+              );
+              const updateCollisionWarning = () => {
+                const v = nameInput.value.trim();
+                if (v && icons.includes(v)) {
+                  collisionWarning.textContent = _(
+                    "Will replace the existing '%s'.",
+                  ).format(v);
+                  collisionWarning.style.display = "";
+                } else {
+                  collisionWarning.style.display = "none";
+                }
+              };
+              nameInput.addEventListener("input", updateCollisionWarning);
+              updateCollisionWarning();
               return {
                 el: E(
                   "div",
@@ -2551,13 +2573,16 @@ return view.extend({
                     style:
                       "display:flex;gap:0.6em;flex-wrap:wrap;align-items:center;",
                   },
-                  [nameInput],
+                  [nameInput, collisionWarning],
                 ),
                 value: () => ({ name: nameInput.value.trim() }),
                 valid: () => {
                   const v = nameInput.value.trim();
                   return (
-                    !!v && !v.includes("/") && ICON_EXTS.includes(assetUpload.extOf(v))
+                    !!v &&
+                    !v.includes("/") &&
+                    !v.includes("..") &&
+                    ICON_EXTS.includes(assetUpload.extOf(v))
                   );
                 },
               };

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2191,32 +2191,31 @@ return view.extend({
             const nameInput = E("input", {
               type: "text",
               class: "cbi-input-text",
-              style: "flex:1;min-width:11em;",
               placeholder: _("Font family name, e.g. MiSans"),
               value: familyFromFilename(file.name),
             });
             const slotSelect = E(
               "select",
-              { class: "cbi-input-select", style: "max-width:10em;" },
+              { class: "cbi-input-select" },
               [
                 E("option", { value: "sans" }, _("Sans-Serif")),
                 E("option", { value: "mono" }, _("Monospace")),
               ],
             );
             return {
-              el: E(
-                "div",
-                {
-                  style:
-                    "display:flex;gap:0.6em;flex-wrap:wrap;align-items:center;",
-                },
-                [nameInput, slotSelect],
-              ),
+              rows: [
+                { label: _("Name"), control: nameInput },
+                { label: _("Slot"), control: slotSelect },
+              ],
               value: () => ({
                 name: nameInput.value.trim(),
                 slot: slotSelect.value,
               }),
               valid: () => !!nameInput.value.trim(),
+              setDisabled: (disabled) => {
+                nameInput.disabled = disabled;
+                slotSelect.disabled = disabled;
+              },
             };
           },
         },
@@ -2544,16 +2543,14 @@ return view.extend({
               const nameInput = E("input", {
                 type: "text",
                 class: "cbi-input-text",
-                style: "flex:1;min-width:11em;",
-                placeholder: _("Filename (with extension)"),
                 value: file.name,
               });
               const collisionWarning = E(
                 "p",
                 {
                   style:
-                    "color:var(--warning);font-size:0.9em;margin:0;" +
-                    "width:100%;display:none;",
+                    "color:var(--warning);font-size:0.9em;" +
+                    "margin:0.35em 0 0;display:none;",
                 },
                 "",
               );
@@ -2570,15 +2567,28 @@ return view.extend({
               };
               nameInput.addEventListener("input", updateCollisionWarning);
               updateCollisionWarning();
-              return {
-                el: E(
-                  "div",
-                  {
-                    style:
-                      "display:flex;gap:0.6em;flex-wrap:wrap;align-items:center;",
-                  },
-                  [nameInput, collisionWarning],
+              const noteEl = E(
+                "div",
+                {
+                  style:
+                    "font-size:0.82em;color:var(--text-muted);" +
+                    "opacity:0.8;margin-top:0.35em;",
+                },
+                _(
+                  "Name it login-bg.* to use it as the login page background.",
                 ),
+              );
+              return {
+                rows: [
+                  {
+                    label: _("Filename (with extension)"),
+                    control: E("div", {}, [
+                      nameInput,
+                      collisionWarning,
+                      noteEl,
+                    ]),
+                  },
+                ],
                 value: () => ({ name: nameInput.value.trim() }),
                 valid: () => {
                   const v = nameInput.value.trim();
@@ -2589,11 +2599,11 @@ return view.extend({
                     ICON_EXTS.includes(assetUpload.extOf(v))
                   );
                 },
+                setDisabled: (disabled) => {
+                  nameInput.disabled = disabled;
+                },
               };
             },
-            note: _(
-              "Name it login-bg.* to use it as the login page background.",
-            ),
           },
           upload: (file, meta, onProgress) =>
             assetUpload

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2085,73 +2085,28 @@ return view.extend({
     so.rmempty = false;
     so.render = renderContainerMaxWidthControl;
 
-    const fontSection = s.taboption(
+    const fontLibrarySection = s.taboption(
       "layout_typography",
       form.SectionValue,
-      "_font_settings",
+      "_font_library",
       form.NamedSection,
       "theme",
       "aurora",
-      _("Typography"),
+      _("Font Library"),
       _(
-        "Sans-serif and monospace typefaces used across the theme. Webfonts are downloaded once from pinned, checksum-verified sources and served locally; pages never load fonts from the internet.",
+        "Keep custom font files as small as possible, as they are stored in the router's limited flash storage.",
       ),
     );
-    const fontSubsection = fontSection.subsection;
+    const fontLibrarySubsection = fontLibrarySection.subsection;
 
-    const fontSlotOpts = {};
-
-    const findFontByPreset = (slot, preset) =>
-      buildFontOptions(slot).find((font) => font.name === preset);
-
-    const findFontByStack = (slot, stack) =>
-      buildFontOptions(slot).find((font) => font.stack === stack);
-
-    const getDefaultFont = (slot) =>
-      findFontByPreset(slot, "default") || buildFontOptions(slot)[0];
-
-    const addFontSlot = (ss, slot) => {
-      const options = buildFontOptions(slot);
-      const stackKey = "struct_font_" + slot;
-      const defaultFont = getDefaultFont(slot);
-
-      const presetOpt = ss.option(
-        form.ListValue,
-        stackKey,
-        slot === "sans" ? _("Sans-Serif Typeface") : _("Monospace Typeface"),
-      );
-      presetOpt.description =
-        slot === "sans"
-          ? _(
-              "Primary font for all interface text — headings, body, menus, forms, and tables.",
-            )
-          : _("Font for code, command output, and the system log viewer.");
-      presetOpt.default = themeConfig[stackKey] || defaultFont?.stack || "";
-      presetOpt.rmempty = false;
-      options.forEach((font) => {
-        if (font.stack) {
-          presetOpt.value(
-            font.stack,
-            font.source
-              ? "%s (%s)".format(font.label, font.source)
-              : font.label,
-          );
-        }
-      });
-      fontSlotOpts[slot] = presetOpt;
-    };
-
-    addFontSlot(fontSubsection, "sans");
-    addFontSlot(fontSubsection, "mono");
-
-    const customFontsOpt = fontSubsection.option(
+    const fontTableSo = fontLibrarySubsection.option(
       form.DummyValue,
-      "_custom_fonts",
-      _("Custom Fonts"),
+      "_font_table",
+      " ",
     );
-    customFontsOpt.rawhtml = false;
-    customFontsOpt.cfgvalue = () => "";
-    customFontsOpt.render = () => {
+    fontTableSo.rawhtml = false;
+    fontTableSo.cfgvalue = () => "";
+    fontTableSo.render = () => {
       const FONT_TMP_PATH = "/tmp/aurora_font.tmp";
       const customs = fontPresetsBySlot?.custom || [];
 
@@ -2273,20 +2228,67 @@ return view.extend({
             }),
       });
 
-      return E("div", { class: "cbi-value" }, [
-        E("label", { class: "cbi-value-title" }, _("Custom Fonts")),
-        E("div", { class: "cbi-value-field" }, [
-          fontManager,
-          E(
-            "p",
-            { style: "opacity:0.6;font-size:0.9em;margin:0.35em 0 0;" },
-            _(
-              "Keep custom font files as small as possible, as they are stored in the router's limited flash storage.",
-            ),
-          ),
-        ]),
-      ]);
+      return fontManager;
     };
+
+    const fontSection = s.taboption(
+      "layout_typography",
+      form.SectionValue,
+      "_font_settings",
+      form.NamedSection,
+      "theme",
+      "aurora",
+      _("Typography"),
+      _(
+        "Sans-serif and monospace typefaces used across the theme. Webfonts are downloaded once from pinned, checksum-verified sources and served locally; pages never load fonts from the internet.",
+      ),
+    );
+    const fontSubsection = fontSection.subsection;
+
+    const fontSlotOpts = {};
+
+    const findFontByPreset = (slot, preset) =>
+      buildFontOptions(slot).find((font) => font.name === preset);
+
+    const findFontByStack = (slot, stack) =>
+      buildFontOptions(slot).find((font) => font.stack === stack);
+
+    const getDefaultFont = (slot) =>
+      findFontByPreset(slot, "default") || buildFontOptions(slot)[0];
+
+    const addFontSlot = (ss, slot) => {
+      const options = buildFontOptions(slot);
+      const stackKey = "struct_font_" + slot;
+      const defaultFont = getDefaultFont(slot);
+
+      const presetOpt = ss.option(
+        form.ListValue,
+        stackKey,
+        slot === "sans" ? _("Sans-Serif Typeface") : _("Monospace Typeface"),
+      );
+      presetOpt.description =
+        slot === "sans"
+          ? _(
+              "Primary font for all interface text — headings, body, menus, forms, and tables.",
+            )
+          : _("Font for code, command output, and the system log viewer.");
+      presetOpt.default = themeConfig[stackKey] || defaultFont?.stack || "";
+      presetOpt.rmempty = false;
+      options.forEach((font) => {
+        if (font.stack) {
+          presetOpt.value(
+            font.stack,
+            font.source
+              ? "%s (%s)".format(font.label, font.source)
+              : font.label,
+          );
+        }
+      });
+      fontSlotOpts[slot] = presetOpt;
+    };
+
+    addFontSlot(fontSubsection, "sans");
+    addFontSlot(fontSubsection, "mono");
 
     const getFontSelection = (slot) => {
       const value =

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2449,8 +2449,6 @@ return view.extend({
     assetTableSo.load = () => getIconsOnce();
     assetTableSo.cfgvalue = (section_id, data) => data?.icons || [];
     const ICON_EXTS = ["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"];
-    const iconExtOf = (name) =>
-      (name.match(/\.([a-z0-9]+)$/i)?.[1] || "").toLowerCase();
 
     assetTableSo.render = function (option_index, section_id, in_table) {
       return this.load(section_id).then((data) => {
@@ -2527,7 +2525,7 @@ return view.extend({
           rows: icons.map((icon) => ({
             preview: makePreview(icon),
             name: icon,
-            badge: { label: iconExtOf(icon).toUpperCase(), tone: "neutral" },
+            badge: { label: assetUpload.extOf(icon).toUpperCase(), tone: "neutral" },
             size: sizes[icon] || 0,
             onDelete: ui.createHandlerFn(this, () => removeIcon(icon)),
           })),
@@ -2562,7 +2560,7 @@ return view.extend({
                 valid: () => {
                   const v = nameInput.value.trim();
                   return (
-                    !!v && !v.includes("/") && ICON_EXTS.includes(iconExtOf(v))
+                    !!v && !v.includes("/") && ICON_EXTS.includes(assetUpload.extOf(v))
                   );
                 },
               };

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2523,167 +2523,53 @@ return view.extend({
       return this.load(section_id).then((data) => {
         const icons = this.cfgvalue(section_id, data);
         const tmpPath = "/tmp/aurora_icon.tmp";
-
-        const fileInput = E("input", {
-          type: "file",
-          style: "display:none",
-          accept: "image/*,.svg",
-        });
-
-        const progressBar = E("div", {
-          style:
-            "height:100%;width:0%;transition:width 0.15s;border-radius:2px;background:var(--brand);",
-        });
-        const progressFilename = E("span", {}, "");
-        const progressPct = E("span", {}, "0%");
-        const progressRow = E(
-          "div",
-          {
-            style:
-              "display:none;margin-bottom:0.75em;padding:0.6em 0.875em;border-radius:0.375em;border:1px solid var(--hairline);",
-          },
-          [
-            E(
-              "div",
-              {
-                style:
-                  "display:flex;justify-content:space-between;align-items:center;font-size:0.85em;margin-bottom:0.4em;",
-              },
-              [progressFilename, progressPct],
-            ),
-            E(
-              "div",
-              {
-                style:
-                  "height:4px;border-radius:2px;overflow:hidden;background:var(--surface-sunken);",
-              },
-              [progressBar],
-            ),
-          ],
-        );
-
-        const setUploading = (busy) => {
-          dropzone.style.opacity = busy ? "0.5" : "";
-          dropzone.style.pointerEvents = busy ? "none" : "";
-          progressRow.style.display = busy ? "block" : "none";
-        };
-
-        const dropzone = E(
-          "div",
-          {
-            style:
-              "border:2px dashed var(--hairline);border-radius:0.5em;padding:1.25em 1em;text-align:center;cursor:pointer;margin-bottom:0.75em;transition:border-color 0.15s,background 0.15s;",
-            click: () => fileInput.click(),
-            dragover: (e) => {
-              e.preventDefault();
-              dropzone.style.borderColor = "var(--brand)";
-              dropzone.style.background = "var(--brand-subtle)";
-            },
-            dragleave: () => {
-              dropzone.style.borderColor = "";
-              dropzone.style.background = "";
-            },
-            drop: (e) => {
-              e.preventDefault();
-              dropzone.style.borderColor = "";
-              dropzone.style.background = "";
-              const file = e.dataTransfer.files[0];
-              if (file) uploadFile(file);
-            },
-          },
-          [
-            E(
-              "div",
-              {
-                style:
-                  "font-size:1.5em;margin-bottom:0.25em;pointer-events:none;",
-              },
-              "⬆",
-            ),
-            E(
-              "strong",
-              { style: "pointer-events:none;" },
-              _("Drop image asset here, or click to browse"),
-            ),
-            E(
-              "div",
-              {
-                style:
-                  "font-size:0.8em;opacity:0.6;margin-top:0.25em;pointer-events:none;",
-              },
-              _("JPG · PNG · WebP · AVIF · SVG · GIF"),
-            ),
-          ],
-        );
+        const progress = assetUpload.createProgressRow();
 
         const uploadFile = (file) => {
-          fileInput.value = "";
-          progressFilename.textContent = file.name;
-          progressPct.textContent = "0%";
-          progressBar.style.width = "0%";
-          setUploading(true);
-
-          const xhr = new XMLHttpRequest();
-
-          xhr.upload.addEventListener("progress", (e) => {
-            if (e.lengthComputable) {
-              const pct = Math.round((e.loaded / e.total) * 100);
-              progressBar.style.width = pct + "%";
-              progressPct.textContent = pct + "%";
-            }
+          const check = assetUpload.checkFile(file, {
+            exts: ["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"],
           });
+          if (!check.ok) {
+            ui.addNotification(null, E("p", check.err), "error");
+            return;
+          }
+          dropzone.setBusy(true);
+          progress.show();
+          progress.set(0, file.name);
 
-          xhr.addEventListener("load", () => {
-            if (xhr.status !== 200) {
-              setUploading(false);
-              ui.addNotification(
-                null,
-                E("p", _("Upload failed (HTTP %s)").format(xhr.status)),
-                "error",
-              );
-              return;
-            }
-            L.resolveDefault(callUploadIcon(file.name), {}).then((ret) => {
+          assetUpload
+            .uploadToRouter({
+              tmpPath,
+              file,
+              onProgress: (p) => progress.set(p),
+            })
+            .then(() => L.resolveDefault(callUploadIcon(file.name), {}))
+            .then((ret) => {
               if (ret?.result === 0) {
                 if (/^login-bg\./i.test(file.name)) {
                   localStorage.setItem("aurora.pending_bg", file.name);
                 }
                 window.location.reload();
               } else {
-                setUploading(false);
-                ui.addNotification(
-                  null,
-                  E(
-                    "p",
-                    _("Upload failed: %s").format(ret?.error || "Unknown"),
-                  ),
-                  "error",
-                );
-                L.resolveDefault(fs.remove(tmpPath), {});
+                throw new Error(ret?.error || "Unknown");
               }
+            })
+            .catch((err) => {
+              dropzone.setBusy(false);
+              progress.hide();
+              ui.addNotification(
+                null,
+                E("p", _("Upload failed: %s").format(err.message)),
+                "error",
+              );
             });
-          });
-
-          xhr.addEventListener("error", () => {
-            setUploading(false);
-            ui.addNotification(null, E("p", _("Upload failed")), "error");
-          });
-
-          const formData = new FormData();
-          formData.append("sessionid", rpc.getSessionID());
-          formData.append("filename", tmpPath);
-          formData.append("filemode", "0600");
-          formData.append("filedata", file, file.name);
-
-          xhr.open("POST", "/cgi-bin/cgi-upload");
-          xhr.withCredentials = true;
-          xhr.send(formData);
         };
 
-        fileInput.addEventListener("change", () => {
-          const file = fileInput.files[0];
-          fileInput.value = "";
-          if (file) uploadFile(file);
+        const dropzone = assetUpload.createDropzone({
+          hint: _("Drop image asset here, or click to browse"),
+          sub: _("JPG · PNG · WebP · AVIF · SVG · GIF · ICO"),
+          accept: "image/*,.svg,.ico",
+          onFile: uploadFile,
         });
 
         const idleCallback = window.requestIdleCallback
@@ -2721,60 +2607,39 @@ return view.extend({
             "button",
             {
               class: "cbi-button cbi-button-remove",
-              click: ui.createHandlerFn(this, () => {
-                return ui.showModal(_("Delete Brand Asset"), [
-                  E(
-                    "p",
-                    {},
-                    _(
+              click: ui.createHandlerFn(this, () =>
+                assetUpload
+                  .confirmDelete({
+                    title: _("Delete Brand Asset"),
+                    message: _(
                       "Delete '%s' from /www/luci-static/aurora/images/? Theme settings that reference it may need updating.",
                     ).format(icon),
-                  ),
-                  E("div", { class: "right" }, [
-                    E(
-                      "button",
-                      { class: "btn", click: ui.hideModal },
-                      _("Cancel"),
-                    ),
-                    " ",
-                    E(
-                      "button",
-                      {
-                        class: "btn cbi-button-negative",
-                        click: () => {
-                          ui.showModal(_("Deleting…"), [
-                            E("p", { class: "spinning" }, _("Please wait…")),
-                          ]);
-                          L.resolveDefault(callRemoveIcon(icon), {}).then(
-                            (ret) => {
-                              ui.hideModal();
-                              if (ret?.result === 0) {
-                                ui.addNotification(
-                                  null,
-                                  E("p", _("Deleted: %s").format(icon)),
-                                );
-                                window.location.reload();
-                              } else {
-                                ui.addNotification(
-                                  null,
-                                  E(
-                                    "p",
-                                    _("Failed to delete: %s").format(
-                                      ret?.error || "Unknown",
-                                    ),
-                                  ),
-                                  "error",
-                                );
-                              }
-                            },
+                  })
+                  .then((confirmed) => {
+                    if (!confirmed) return;
+                    ui.showModal(_("Deleting…"), [
+                      E("p", { class: "spinning" }, _("Please wait…")),
+                    ]);
+                    return L.resolveDefault(callRemoveIcon(icon), {}).then(
+                      (ret) => {
+                        ui.hideModal();
+                        if (ret?.result === 0) {
+                          ui.addNotification(
+                            null,
+                            E("p", _("Deleted: %s").format(icon)),
                           );
-                        },
+                          window.location.reload();
+                        } else {
+                          ui.addNotification(
+                            null,
+                            E("p", _("Delete failed")),
+                            "error",
+                          );
+                        }
                       },
-                      _("Delete"),
-                    ),
-                  ]),
-                ]);
-              }),
+                    );
+                  }),
+              ),
             },
             _("Delete"),
           );
@@ -2801,9 +2666,8 @@ return view.extend({
               ]);
 
         return E("div", { "data-name": this.option }, [
-          fileInput,
           dropzone,
-          progressRow,
+          progress.el,
           tableOrEmpty,
         ]);
       });

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2632,7 +2632,12 @@ return view.extend({
                         } else {
                           ui.addNotification(
                             null,
-                            E("p", _("Delete failed")),
+                            E(
+                              "p",
+                              _("Failed to delete: %s").format(
+                                ret?.error || "Unknown",
+                              ),
+                            ),
                             "error",
                           );
                         }

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2094,7 +2094,7 @@ return view.extend({
       "aurora",
       _("Typography"),
       _(
-        "Sans-serif and monospace typefaces used across the theme. Webfonts are downloaded once from pinned, checksum-verified sources and served locally; pages never load fonts from the internet.",
+        "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files.",
       ),
     );
     const fontSubsection = fontSection.subsection;

--- a/htdocs/luci-static/resources/view/aurora/theme.js
+++ b/htdocs/luci-static/resources/view/aurora/theme.js
@@ -2551,7 +2551,7 @@ return view.extend({
                 }
                 window.location.reload();
               } else {
-                throw new Error(ret?.error || "Unknown");
+                throw new Error(ret?.error || _("Unknown"));
               }
             })
             .catch((err) => {
@@ -2671,7 +2671,7 @@ return view.extend({
               ]);
 
         return E("div", { "data-name": this.option }, [
-          dropzone,
+          E("div", { style: "margin-bottom:0.75em;" }, dropzone),
           progress.el,
           tableOrEmpty,
         ]);

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -315,6 +315,10 @@ msgid "Confirm Upload"
 msgstr "Hochladen bestätigen"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Eigene Schriftarten"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Datei entfernen"
 

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -324,8 +324,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "„%s“ löschen? Die Oberfläche fällt auf die Standardschriftart zurück."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Eigene Schriftarten werden im begrenzten Flash-Speicher des Routers gespeichert und von jedem Browser beim ersten Laden heruntergeladen. Für CJK-Schriftarten empfiehlt sich eine reduzierte .woff2 mit nur den benötigten Glyphen, um Speicherplatz zu sparen und das Laden zu beschleunigen."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Halten Sie eigene Schriftdateien möglichst klein, da sie im begrenzten Flash-Speicher des Routers gespeichert werden."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -42,10 +42,6 @@ msgstr "Akzent für Warnungen, Hinweise und Validierungsmeldungen."
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Akzente für Benachrichtigungen, Validierung und Status-Feedback."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Aktionen"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -108,10 +104,6 @@ msgid ""
 msgstr ""
 "Sind Sie sicher, dass Sie <strong>%h</strong> auf Version <strong>%h</"
 "strong> aktualisieren möchten?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Dateiname der Ressource"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -294,6 +286,26 @@ msgstr "Benutzerdefiniert"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Eigene Schriftarten"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Name"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Größe"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Typ"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Dateiname (mit Erweiterung)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Mit dem Namen login-bg.* wird die Datei als Hintergrund der Anmeldeseite verwendet."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -474,10 +486,6 @@ msgstr "Löschen fehlgeschlagen: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Schwacher Hover-Effekt"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Schriftname"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -831,10 +839,6 @@ msgstr "Preset"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Preset erfolgreich angewendet."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Vorschau"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -299,6 +299,10 @@ msgstr "Benutzerdefiniert"
 msgid "Custom Fonts"
 msgstr "Eigene Schriftarten"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Eigene Schriftarten werden im begrenzten Flash-Speicher des Routers gespeichert und von jedem Browser beim ersten Laden heruntergeladen. Für CJK-Schriftarten empfiehlt sich eine reduzierte .woff2 mit nur den benötigten Glyphen, um Speicherplatz zu sparen und das Laden zu beschleunigen."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Gefahr"
@@ -758,8 +762,8 @@ msgid "On-Brand Text"
 msgstr "Text auf Brand-Hintergrund"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Nur .woff2-Dateien bis 4 MB werden akzeptiert."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Nur .woff2-Dateien bis 8 MB werden akzeptiert."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -286,7 +286,7 @@ msgstr "Benutzerdefiniert"
 msgid "Name"
 msgstr "Name"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Größe"
 
@@ -310,7 +310,7 @@ msgstr "Ersetzt die vorhandene Datei „%s“."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Eine .woff2-Schriftart hierher ziehen oder klicken zum Auswählen"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Hochladen bestätigen"
 
@@ -318,11 +318,11 @@ msgstr "Hochladen bestätigen"
 msgid "Custom Fonts"
 msgstr "Eigene Schriftarten"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Nicht unterstützter Dateityp. Erlaubt: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Die Datei ist %s groß und überschreitet das 8-MB-Limit."
 
@@ -363,9 +363,7 @@ msgid "Default foreground for headings, body text, icons, and form values."
 msgstr ""
 "Standard-Vordergrund für Überschriften, Fließtext, Icons und Formularwerte."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Löschen"
 
@@ -1182,12 +1180,11 @@ msgstr ""
 "und verwalten. Dateien werden in <code>/www/luci-static/aurora/images/</"
 "code> gespeichert."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Upload fehlgeschlagen"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Upload fehlgeschlagen (HTTP %s)"
 

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -286,6 +286,7 @@ msgstr "Benutzerdefiniert"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Eigene Schriftarten"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Name"
@@ -306,6 +307,9 @@ msgstr "Dateiname (mit Erweiterung)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Mit dem Namen login-bg.* wird die Datei als Hintergrund der Anmeldeseite verwendet."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Ersetzt die vorhandene Datei „%s“."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -319,10 +319,6 @@ msgid "Custom Fonts"
 msgstr "Eigene Schriftarten"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Datei entfernen"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Nicht unterstützter Dateityp. Erlaubt: %s"
 

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -338,10 +338,6 @@ msgstr "„%s“ löschen? Die Oberfläche fällt auf die Standardschriftart zur
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Halten Sie eigene Schriftdateien möglichst klein, da sie im begrenzten Flash-Speicher des Routers gespeichert werden."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Schriftbibliothek"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Gefahr"

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -930,14 +930,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Serifenlose Schriftart"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Serifenlose und Monospace-Schriften für das gesamte Theme. Webfonts werden "
-"einmalig aus versionsfixierten, per Prüfsumme verifizierten Quellen geladen "
-"und lokal ausgeliefert; Seiten laden niemals Schriften aus dem Internet."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Serifenlose und Monospace-Schriften für das gesamte Theme. Wählen Sie einen kuratierten Webfont — nach dem Speichern einmalig aus versionsfixierten, per Prüfsumme verifizierten Quellen geladen und anschließend lokal ausgeliefert — oder laden Sie eigene .woff2-Dateien hoch."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -321,7 +321,7 @@ msgstr "Eigene Schriftart löschen"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Delete '%s'? The interface will fall back to the default typeface."
-msgstr "Löschen „%s”? Die Oberfläche fällt auf die Standardschriftart zurück."
+msgstr "„%s“ löschen? Die Oberfläche fällt auf die Standardschriftart zurück."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -282,11 +282,6 @@ msgstr "Eckenradius"
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Eigene Schriftarten"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Name"
@@ -342,6 +337,10 @@ msgstr "„%s“ löschen? Die Oberfläche fällt auf die Standardschriftart zur
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Halten Sie eigene Schriftdateien möglichst klein, da sie im begrenzten Flash-Speicher des Routers gespeichert werden."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Schriftbibliothek"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -242,10 +242,6 @@ msgstr "Es wird nach Updates gesucht..."
 msgid "Checking..."
 msgstr "Prüfung..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Bitte eine .woff2-Datei auswählen und einen Schriftnamen angeben"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Wählen Sie eine genaue Farbe für dieses Token"
@@ -298,6 +294,34 @@ msgstr "Benutzerdefiniert"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Eigene Schriftarten"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Eine .woff2-Schriftart hierher ziehen oder klicken zum Auswählen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Hochladen bestätigen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Datei entfernen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Nicht unterstützter Dateityp. Erlaubt: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Die Datei ist %s groß und überschreitet das 8-MB-Limit."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Eigene Schriftart löschen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "Löschen „%s”? Die Oberfläche fällt auf die Standardschriftart zurück."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -630,8 +654,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Ungültiger, fehlender oder zyklischer Farbausdruck."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1159,11 +1183,6 @@ msgstr "Paket wird aktualisiert"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Hochladen"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Eigene Schriftart hochladen"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/de/aurora-config.po
+++ b/po/de/aurora-config.po
@@ -495,10 +495,6 @@ msgstr ""
 "Felder akzeptieren #hex, rgb(), hsl(), lab() und oklch(). Die Farbauswahl "
 "füllt Hex aus; andere Formate können eingegeben werden."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Datei"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1179,10 +1175,6 @@ msgstr "Aktualisierung fehlgeschlagen: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Paket wird aktualisiert"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Hochladen"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -313,6 +313,10 @@ msgid "Confirm Upload"
 msgstr "Confirmar subida"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Fuentes personalizadas"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Quitar archivo"
 

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -284,7 +284,7 @@ msgstr "Personalizada"
 msgid "Name"
 msgstr "Nombre"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Tamaño"
 
@@ -308,7 +308,7 @@ msgstr "Reemplazará el archivo existente «%s»."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Arrastra una fuente .woff2 aquí o haz clic para elegir"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Confirmar subida"
 
@@ -316,11 +316,11 @@ msgstr "Confirmar subida"
 msgid "Custom Fonts"
 msgstr "Fuentes personalizadas"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Tipo de archivo no compatible. Permitidos: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "El archivo ocupa %s y supera el límite de 8 MB."
 
@@ -362,9 +362,7 @@ msgstr ""
 "Color de primer plano por defecto para encabezados, texto del cuerpo, iconos "
 "y valores de formularios."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -1185,12 +1183,11 @@ msgstr ""
 "de inicio de sesión. Los archivos se almacenan en <code>/www/luci-static/"
 "aurora/images/</code>."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Error al subir"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Error al subir (HTTP %s)"
 

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -317,10 +317,6 @@ msgid "Custom Fonts"
 msgstr "Fuentes personalizadas"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Quitar archivo"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Tipo de archivo no compatible. Permitidos: %s"
 

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -297,6 +297,10 @@ msgstr "Personalizada"
 msgid "Custom Fonts"
 msgstr "Fuentes personalizadas"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Las fuentes personalizadas se almacenan en el limitado almacenamiento flash del router y cada navegador las descarga en la primera carga. Para tipografías CJK, es preferible un .woff2 con subconjunto que incluya solo los glifos necesarios, para ahorrar espacio y cargar más rápido."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Peligro"
@@ -762,8 +766,8 @@ msgid "On-Brand Text"
 msgstr "Texto sobre fondo de marca"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Solo se aceptan archivos .woff2 de hasta 4 MB."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Solo se aceptan archivos .woff2 de hasta 8 MB."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -336,10 +336,6 @@ msgstr "¿Eliminar «%s»? La interfaz volverá a la tipografía predeterminada.
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Mantén los archivos de fuentes personalizadas lo más pequeños posible, ya que se almacenan en el limitado almacenamiento flash del router."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Biblioteca de fuentes"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Peligro"

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -934,15 +934,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Tipografía Sans-Serif"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Fuentes sans serif y monoespaciadas usadas en todo el tema. Las fuentes web "
-"se descargan una sola vez desde orígenes con versión fijada y verificados "
-"por suma de comprobación, y se sirven localmente; las páginas nunca cargan "
-"fuentes desde Internet."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Fuentes sans serif y monoespaciadas usadas en todo el tema. Elige una fuente web seleccionada —se descarga una sola vez al guardar, desde orígenes con versión fijada y verificados por suma de comprobación, y luego se sirve localmente— o sube tus propios archivos .woff2."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -322,8 +322,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "¿Eliminar «%s»? La interfaz volverá a la tipografía predeterminada."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Las fuentes personalizadas se almacenan en el limitado almacenamiento flash del router y cada navegador las descarga en la primera carga. Para tipografías CJK, es preferible un .woff2 con subconjunto que incluya solo los glifos necesarios, para ahorrar espacio y cargar más rápido."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Mantén los archivos de fuentes personalizadas lo más pequeños posible, ya que se almacenan en el limitado almacenamiento flash del router."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -492,10 +492,6 @@ msgstr ""
 "Los campos aceptan #hex, rgb(), hsl(), lab() y oklch(). El selector completa "
 "en hex; se pueden escribir otros formatos manualmente."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Archivo"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1183,10 +1179,6 @@ msgstr "Error en la actualización: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Actualizando paquete"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Subir"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -280,11 +280,6 @@ msgstr "Radio de esquina"
 msgid "Custom"
 msgstr "Personalizada"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Fuentes personalizadas"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nombre"
@@ -340,6 +335,10 @@ msgstr "¿Eliminar «%s»? La interfaz volverá a la tipografía predeterminada.
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Mantén los archivos de fuentes personalizadas lo más pequeños posible, ya que se almacenan en el limitado almacenamiento flash del router."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Biblioteca de fuentes"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -240,10 +240,6 @@ msgstr "Buscando actualizaciones..."
 msgid "Checking..."
 msgstr "Comprobando..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Elija un archivo .woff2 e indique el nombre de la fuente"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Elija un color literal para este token"
@@ -296,6 +292,34 @@ msgstr "Personalizada"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Fuentes personalizadas"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Arrastra una fuente .woff2 aquí o haz clic para elegir"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Confirmar subida"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Quitar archivo"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Tipo de archivo no compatible. Permitidos: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "El archivo ocupa %s y supera el límite de 8 MB."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Eliminar fuente personalizada"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "¿Eliminar «%s»? La interfaz volverá a la tipografía predeterminada."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -635,8 +659,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Expresión de color no válida, ausente o cíclica."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1163,11 +1187,6 @@ msgstr "Actualizando paquete"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Subir"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Subir fuente personalizada"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -42,10 +42,6 @@ msgstr "Acento para advertencias, avisos y mensajes de validación."
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Acentos para notificaciones, validación y retroalimentación de estado."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Acciones"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -108,10 +104,6 @@ msgid ""
 msgstr ""
 "¿Está seguro de que desea actualizar <strong>%h</strong> a la versión "
 "<strong>%h</strong>?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Nombre de archivo del recurso"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -292,6 +284,26 @@ msgstr "Personalizada"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Fuentes personalizadas"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Nombre"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Tamaño"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Tipo"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Nombre de archivo (con extensión)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Nómbralo login-bg.* para usarlo como fondo de la página de inicio de sesión."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -471,10 +483,6 @@ msgstr "Error al eliminar: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Hover tenue"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Nombre de fuente"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -834,10 +842,6 @@ msgstr "Preset"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Preset aplicado correctamente."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Vista previa"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/es/aurora-config.po
+++ b/po/es/aurora-config.po
@@ -284,6 +284,7 @@ msgstr "Personalizada"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Fuentes personalizadas"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nombre"
@@ -304,6 +305,9 @@ msgstr "Nombre de archivo (con extensión)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Nómbralo login-bg.* para usarlo como fondo de la página de inicio de sesión."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Reemplazará el archivo existente «%s»."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -294,11 +294,6 @@ msgstr "Rayon des coins"
 msgid "Custom"
 msgstr "Personnalisée"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Polices personnalisées"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nom"
@@ -354,6 +349,10 @@ msgstr "Supprimer « %s » ? L'interface reviendra à la police par défaut."
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Gardez les fichiers de polices personnalisées aussi petits que possible, car ils sont stockés dans la mémoire flash limitée du routeur."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Bibliothèque de polices"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -311,6 +311,10 @@ msgstr "Personnalisée"
 msgid "Custom Fonts"
 msgstr "Polices personnalisées"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Les polices personnalisées sont stockées dans la mémoire flash limitée du routeur et téléchargées par chaque navigateur au premier chargement. Pour les polices CJK, privilégiez un .woff2 sous-ensemble ne contenant que les glyphes nécessaires, afin d'économiser de l'espace et d'accélérer le chargement."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Danger"
@@ -780,8 +784,8 @@ msgid "On-Brand Text"
 msgstr "Texte sur fond de marque"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Seuls les fichiers .woff2 de 4 Mo maximum sont acceptés."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Seuls les fichiers .woff2 de 8 Mo maximum sont acceptés."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -953,15 +953,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Police sans-serif"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Polices sans serif et monospace utilisées dans tout le thème. Les polices "
-"web sont téléchargées une seule fois depuis des sources à version figée et "
-"vérifiées par somme de contrôle, puis servies localement ; les pages ne "
-"chargent jamais de polices depuis Internet."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Polices sans serif et monospace utilisées dans tout le thème. Choisissez une police web sélectionnée — téléchargée une seule fois après l'enregistrement, depuis des sources à version figée et vérifiées par somme de contrôle, puis servie localement — ou téléversez vos propres fichiers .woff2."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -298,6 +298,7 @@ msgstr "Personnalisée"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Polices personnalisées"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nom"
@@ -318,6 +319,9 @@ msgstr "Nom de fichier (avec extension)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Nommez-le login-bg.* pour l'utiliser comme arrière-plan de la page de connexion."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Remplacera le fichier existant « %s »."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -254,10 +254,6 @@ msgstr "Vérification des mises à jour..."
 msgid "Checking..."
 msgstr "Vérification..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Choisissez un fichier .woff2 et indiquez le nom de la police"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Choisissez une couleur littérale pour ce token"
@@ -310,6 +306,34 @@ msgstr "Personnalisée"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Polices personnalisées"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Déposez une police .woff2 ici ou cliquez pour parcourir"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Confirmer l'envoi"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Retirer le fichier"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Type de fichier non pris en charge. Autorisés : %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Le fichier pèse %s et dépasse la limite de 8 Mo."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Supprimer la police personnalisée"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "Supprimer « %s » ? L'interface reviendra à la police par défaut."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -651,8 +675,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Expression de couleur non valide, manquante ou cyclique."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1182,11 +1206,6 @@ msgstr "Mise à jour du paquet"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Téléverser"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Téléverser une police personnalisée"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -298,7 +298,7 @@ msgstr "Personnalisée"
 msgid "Name"
 msgstr "Nom"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Taille"
 
@@ -322,7 +322,7 @@ msgstr "Remplacera le fichier existant « %s »."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Déposez une police .woff2 ici ou cliquez pour parcourir"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Confirmer l'envoi"
 
@@ -330,11 +330,11 @@ msgstr "Confirmer l'envoi"
 msgid "Custom Fonts"
 msgstr "Polices personnalisées"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Type de fichier non pris en charge. Autorisés : %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Le fichier pèse %s et dépasse la limite de 8 Mo."
 
@@ -376,9 +376,7 @@ msgstr ""
 "Premier plan par défaut pour les titres, le corps de texte, les icônes et "
 "les valeurs de formulaire."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -1204,12 +1202,11 @@ msgstr ""
 "l'arrière-plan de connexion. Les fichiers sont stockés dans <code>/www/luci-"
 "static/aurora/images/</code>."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Échec du téléversement"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Échec du téléversement (HTTP %s)"
 

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -350,10 +350,6 @@ msgstr "Supprimer « %s » ? L'interface reviendra à la police par défaut."
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Gardez les fichiers de polices personnalisées aussi petits que possible, car ils sont stockés dans la mémoire flash limitée du routeur."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Bibliothèque de polices"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Danger"

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -331,10 +331,6 @@ msgid "Custom Fonts"
 msgstr "Polices personnalisées"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Retirer le fichier"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Type de fichier non pris en charge. Autorisés : %s"
 

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -507,10 +507,6 @@ msgstr ""
 "sélecteur remplit en hex ; les autres formats peuvent être saisis "
 "manuellement."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Fichier"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1202,10 +1198,6 @@ msgstr "Échec de la mise à jour : %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Mise à jour du paquet"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Téléverser"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -48,10 +48,6 @@ msgstr ""
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Accents pour les notifications, la validation et les retours d'état."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Actions"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -115,10 +111,6 @@ msgid ""
 msgstr ""
 "Êtes-vous sûr de vouloir mettre à jour <strong>%h</strong> vers la version "
 "<strong>%h</strong> ?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Nom du fichier de la ressource"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -306,6 +298,26 @@ msgstr "Personnalisée"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Polices personnalisées"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Nom"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Taille"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Type"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Nom de fichier (avec extension)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Nommez-le login-bg.* pour l'utiliser comme arrière-plan de la page de connexion."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -485,10 +497,6 @@ msgstr "Échec de la suppression : %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Survol léger"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Nom de la police"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -852,10 +860,6 @@ msgstr "Préréglage"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Préréglage appliqué avec succès."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Aperçu"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -327,6 +327,10 @@ msgid "Confirm Upload"
 msgstr "Confirmer l'envoi"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Polices personnalisées"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Retirer le fichier"
 

--- a/po/fr/aurora-config.po
+++ b/po/fr/aurora-config.po
@@ -336,8 +336,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "Supprimer « %s » ? L'interface reviendra à la police par défaut."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Les polices personnalisées sont stockées dans la mémoire flash limitée du routeur et téléchargées par chaque navigateur au premier chargement. Pour les polices CJK, privilégiez un .woff2 sous-ensemble ne contenant que les glyphes nécessaires, afin d'économiser de l'espace et d'accélérer le chargement."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Gardez les fichiers de polices personnalisées aussi petits que possible, car ils sont stockés dans la mémoire flash limitée du routeur."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -279,7 +279,7 @@ msgstr "Kustom"
 msgid "Name"
 msgstr "Nama"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Ukuran"
 
@@ -303,7 +303,7 @@ msgstr "Akan menggantikan berkas '%s' yang sudah ada."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Seret fon .woff2 ke sini, atau klik untuk memilih"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Konfirmasi Unggah"
 
@@ -311,11 +311,11 @@ msgstr "Konfirmasi Unggah"
 msgid "Custom Fonts"
 msgstr "Fon Kustom"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Jenis berkas tidak didukung. Diizinkan: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Ukuran berkas %s, melebihi batas 8MB."
 
@@ -355,9 +355,7 @@ msgstr "Bawaan"
 msgid "Default foreground for headings, body text, icons, and form values."
 msgstr "Latar depan bawaan untuk tajuk, teks isi, ikon, dan nilai formulir."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Hapus"
 
@@ -1158,12 +1156,11 @@ msgstr ""
 "Unggah dan kelola gambar untuk ikon, favicon, aset PWA, dan latar belakang "
 "login. File disimpan di <code>/www/luci-static/aurora/images/</code>."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Unggahan gagal"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Unggahan gagal (HTTP %s)"
 

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -292,6 +292,10 @@ msgstr "Kustom"
 msgid "Custom Fonts"
 msgstr "Fon Kustom"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Fon kustom disimpan di penyimpanan flash router yang terbatas dan diunduh oleh setiap peramban saat pemuatan pertama. Untuk fon CJK, sebaiknya gunakan .woff2 subset yang hanya berisi glif yang diperlukan agar menghemat ruang dan memuat lebih cepat."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Bahaya"
@@ -741,8 +745,8 @@ msgid "On-Brand Text"
 msgstr "Teks Atas Merek"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Hanya berkas .woff2 hingga 4MB yang diterima."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Hanya berkas .woff2 hingga 8MB yang diterima."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -275,11 +275,6 @@ msgstr "Radius Sudut"
 msgid "Custom"
 msgstr "Kustom"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Fon Kustom"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nama"
@@ -335,6 +330,10 @@ msgstr "Hapus '%s'? Antarmuka akan kembali ke fon bawaan."
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Usahakan berkas fon kustom sekecil mungkin karena disimpan di penyimpanan flash router yang terbatas."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Pustaka Fon"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -910,14 +910,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Rupa Huruf Sans-Serif"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Fon sans-serif dan monospace yang digunakan di seluruh tema. Webfont diunduh "
-"sekali dari sumber terkunci versi dan terverifikasi checksum, lalu disajikan "
-"secara lokal; halaman tidak pernah memuat fon dari internet."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Fon sans-serif dan monospace yang digunakan di seluruh tema. Pilih webfont pilihan — diunduh sekali setelah disimpan, dari sumber terkunci versi dan terverifikasi checksum, lalu disajikan secara lokal — atau unggah berkas .woff2 Anda sendiri."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -235,10 +235,6 @@ msgstr "Memeriksa pembaruan..."
 msgid "Checking..."
 msgstr "Memeriksa..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Pilih berkas .woff2 dan isi nama fon"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Pilih warna literal untuk token ini"
@@ -291,6 +287,34 @@ msgstr "Kustom"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Fon Kustom"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Seret fon .woff2 ke sini, atau klik untuk memilih"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Konfirmasi Unggah"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Hapus berkas"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Jenis berkas tidak didukung. Diizinkan: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Ukuran berkas %s, melebihi batas 8MB."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Hapus Fon Kustom"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "Hapus '%s'? Antarmuka akan kembali ke fon bawaan."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -614,8 +638,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Ekspresi warna tidak valid, hilang, atau melingkar."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1136,11 +1160,6 @@ msgstr "Memperbarui Paket"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Unggah"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Unggah Fon Kustom"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -41,10 +41,6 @@ msgstr "Aksen untuk peringatan, pemberitahuan, dan pesan validasi."
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Aksen untuk notifikasi, validasi, dan umpan balik status."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Tindakan"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -107,10 +103,6 @@ msgid ""
 msgstr ""
 "Apakah Anda yakin ingin memperbarui <strong>%h</strong> ke versi <strong>%h</"
 "strong>?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Nama File Aset"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -287,6 +279,26 @@ msgstr "Kustom"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Fon Kustom"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Nama"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Ukuran"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Jenis"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Nama berkas (dengan ekstensi)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Beri nama login-bg.* untuk menjadikannya latar belakang halaman masuk."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -462,10 +474,6 @@ msgstr "Gagal menghapus: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Sorotan Tipis"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Nama fon"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -811,10 +819,6 @@ msgstr "Prasetel"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Prasetel berhasil diterapkan."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Pratinjau"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -331,10 +331,6 @@ msgstr "Hapus '%s'? Antarmuka akan kembali ke fon bawaan."
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Usahakan berkas fon kustom sekecil mungkin karena disimpan di penyimpanan flash router yang terbatas."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Pustaka Fon"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Bahaya"

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -279,6 +279,7 @@ msgstr "Kustom"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Fon Kustom"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nama"
@@ -299,6 +300,9 @@ msgstr "Nama berkas (dengan ekstensi)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Beri nama login-bg.* untuk menjadikannya latar belakang halaman masuk."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Akan menggantikan berkas '%s' yang sudah ada."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -483,10 +483,6 @@ msgstr ""
 "Kolom menerima format #hex, rgb(), hsl(), lab(), dan oklch(). Alat pemilih "
 "akan mengisi format hex; format lain dapat diketik secara manual."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Berkas"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1156,10 +1152,6 @@ msgstr "Pembaruan gagal: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Memperbarui Paket"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Unggah"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -308,6 +308,10 @@ msgid "Confirm Upload"
 msgstr "Konfirmasi Unggah"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Fon Kustom"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Hapus berkas"
 

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -312,10 +312,6 @@ msgid "Custom Fonts"
 msgstr "Fon Kustom"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Hapus berkas"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Jenis berkas tidak didukung. Diizinkan: %s"
 

--- a/po/id/aurora-config.po
+++ b/po/id/aurora-config.po
@@ -317,8 +317,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "Hapus '%s'? Antarmuka akan kembali ke fon bawaan."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Fon kustom disimpan di penyimpanan flash router yang terbatas dan diunduh oleh setiap peramban saat pemuatan pertama. Untuk fon CJK, sebaiknya gunakan .woff2 subset yang hanya berisi glif yang diperlukan agar menghemat ruang dan memuat lebih cepat."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Usahakan berkas fon kustom sekecil mungkin karena disimpan di penyimpanan flash router yang terbatas."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -488,10 +488,6 @@ msgstr ""
 "I campi accettano #hex, rgb(), hsl(), lab() e oklch(). Il selettore "
 "inserisce l'esadecimale; gli altri formati si possono digitare."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "File"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1173,10 +1169,6 @@ msgstr "Aggiornamento fallito: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Aggiornamento del pacchetto..."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Carica"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -41,10 +41,6 @@ msgstr "Accento per avvertimenti, notifiche e messaggi di validazione."
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Accenti per notifiche, validazione e feedback di stato."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Azioni"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -108,10 +104,6 @@ msgid ""
 msgstr ""
 "Sei sicuro di voler aggiornare <strong>%h</strong> alla versione <strong>%h</"
 "strong>?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Nome del file della risorsa"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -289,6 +281,26 @@ msgstr "Personalizzato"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Font personalizzati"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Nome"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Dimensione"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Tipo"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Nome file (con estensione)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Rinominalo in login-bg.* per usarlo come sfondo della pagina di accesso."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -467,10 +479,6 @@ msgstr "Eliminazione fallita: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Hover leggero"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Nome del font"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -827,10 +835,6 @@ msgstr "Preset"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Preset applicato con successo."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Anteprima"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -310,6 +310,10 @@ msgid "Confirm Upload"
 msgstr "Conferma caricamento"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Font personalizzati"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Rimuovi file"
 

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -277,11 +277,6 @@ msgstr "Raggio dell'angolo"
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Font personalizzati"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nome"
@@ -337,6 +332,10 @@ msgstr "Eliminare «%s»? L'interfaccia tornerà al carattere predefinito."
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Mantieni i file dei font personalizzati il più piccoli possibile, poiché vengono salvati nella memoria flash limitata del router."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Libreria font"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -314,10 +314,6 @@ msgid "Custom Fonts"
 msgstr "Font personalizzati"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Rimuovi file"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Tipo di file non supportato. Consentiti: %s"
 

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -319,8 +319,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "Eliminare «%s»? L'interfaccia tornerà al carattere predefinito."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "I font personalizzati vengono salvati nella memoria flash limitata del router e scaricati da ogni browser al primo caricamento. Per i font CJK è preferibile un .woff2 ridotto contenente solo i glifi necessari, così da risparmiare spazio e velocizzare il caricamento."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Mantieni i file dei font personalizzati il più piccoli possibile, poiché vengono salvati nella memoria flash limitata del router."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -294,6 +294,10 @@ msgstr "Personalizzato"
 msgid "Custom Fonts"
 msgstr "Font personalizzati"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "I font personalizzati vengono salvati nella memoria flash limitata del router e scaricati da ogni browser al primo caricamento. Per i font CJK è preferibile un .woff2 ridotto contenente solo i glifi necessari, così da risparmiare spazio e velocizzare il caricamento."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Pericolo"
@@ -755,8 +759,8 @@ msgid "On-Brand Text"
 msgstr "Testo sul brand"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Sono accettati solo file .woff2 fino a 4 MB."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Sono accettati solo file .woff2 fino a 8 MB."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -281,7 +281,7 @@ msgstr "Personalizzato"
 msgid "Name"
 msgstr "Nome"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Dimensione"
 
@@ -305,7 +305,7 @@ msgstr "Sostituirà il file esistente «%s»."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Trascina qui un font .woff2 oppure fai clic per sfogliare"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Conferma caricamento"
 
@@ -313,11 +313,11 @@ msgstr "Conferma caricamento"
 msgid "Custom Fonts"
 msgstr "Font personalizzati"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Tipo di file non supportato. Consentiti: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Il file è di %s e supera il limite di 8 MB."
 
@@ -359,9 +359,7 @@ msgstr ""
 "Primo piano predefinito per intestazioni, testo del corpo, icone e valori "
 "del modulo."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Elimina"
 
@@ -1176,12 +1174,11 @@ msgstr ""
 "pagina di accesso. I file sono salvati in <code>/www/luci-static/aurora/"
 "images/</code>."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Caricamento fallito"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Caricamento fallito (HTTP %s)"
 

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -926,14 +926,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Carattere Sans-Serif"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Font sans serif e monospace usati in tutto il tema. I webfont vengono "
-"scaricati una sola volta da fonti a versione bloccata e verificate tramite "
-"checksum, e serviti localmente; le pagine non caricano mai font da Internet."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Font sans serif e monospace usati in tutto il tema. Scegli un webfont selezionato — scaricato una sola volta dopo il salvataggio, da fonti a versione bloccata e verificate tramite checksum, poi servito localmente — oppure carica i tuoi file .woff2."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -333,10 +333,6 @@ msgstr "Eliminare «%s»? L'interfaccia tornerà al carattere predefinito."
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Mantieni i file dei font personalizzati il più piccoli possibile, poiché vengono salvati nella memoria flash limitata del router."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Libreria font"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Pericolo"

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -281,6 +281,7 @@ msgstr "Personalizzato"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Font personalizzati"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nome"
@@ -301,6 +302,9 @@ msgstr "Nome file (con estensione)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Rinominalo in login-bg.* per usarlo come sfondo della pagina di accesso."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Sostituirà il file esistente «%s»."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/it/aurora-config.po
+++ b/po/it/aurora-config.po
@@ -237,10 +237,6 @@ msgstr "Verifica degli aggiornamenti..."
 msgid "Checking..."
 msgstr "Verifica..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Scegli un file .woff2 e indica il nome del font"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Scegli un colore letterale per questo token"
@@ -293,6 +289,34 @@ msgstr "Personalizzato"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Font personalizzati"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Trascina qui un font .woff2 oppure fai clic per sfogliare"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Conferma caricamento"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Rimuovi file"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Tipo di file non supportato. Consentiti: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Il file è di %s e supera il limite di 8 MB."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Elimina font personalizzato"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "Eliminare «%s»? L'interfaccia tornerà al carattere predefinito."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -628,8 +652,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Espressione del colore non valida, mancante o ciclica."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1153,11 +1177,6 @@ msgstr "Aggiornamento del pacchetto..."
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Carica"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Carica font personalizzato"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -929,15 +929,8 @@ msgid "Sans-Serif Typeface"
 msgstr "サンセリフ書体"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"テーマ全体で使用するサンセリフおよび等幅フォントです。Web フォントはバージョ"
-"ン固定・チェックサム検証済みのソースから一度だけダウンロードされ、ローカルか"
-"ら配信されます。ページがインターネットからフォントを読み込むことはありませ"
-"ん。"
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "テーマ全体で使用するサンセリフおよび等幅フォントです。厳選された Web フォント(保存後に、バージョン固定・チェックサム検証済みのソースから一度だけダウンロードされ、以後ローカルから配信)を選ぶか、独自の .woff2 ファイルをアップロードできます。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -321,10 +321,6 @@ msgid "Custom Fonts"
 msgstr "カスタムフォント"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "ファイルを削除"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "対応していないファイル形式です。対応形式: %s"
 

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -340,10 +340,6 @@ msgstr "「%s」を削除しますか?インターフェイスは既定のフォ
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "カスタムフォントのファイルは、ルーターの限られたフラッシュストレージに保存されるため、できるだけ小さくしてください。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "フォントライブラリ"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "危険"

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -244,10 +244,6 @@ msgstr "アップデートを確認中..."
 msgid "Checking..."
 msgstr "確認中..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr ".woff2 ファイルを選択し、フォント名を入力してください"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "このトークンの具体的な色を選択してください"
@@ -300,6 +296,34 @@ msgstr "カスタム"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "カスタムフォント"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr ".woff2 フォントをここにドラッグするか、クリックして選択してください"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "アップロードを確定"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "ファイルを削除"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "対応していないファイル形式です。対応形式: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "ファイルサイズが %s で、8MB の上限を超えています。"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "カスタムフォントを削除"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "「%s」を削除しますか?インターフェイスは既定のフォントに戻ります。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -629,8 +653,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "カラー表現が無効、欠落、または循環しています。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1156,11 +1180,6 @@ msgstr "パッケージをアップデート中"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "アップロード"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "カスタムフォントをアップロード"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -494,10 +494,6 @@ msgstr ""
 "フィールドは #hex、rgb()、hsl()、lab()、oklch() を受け入れます。ピッカーは "
 "hex を入力しますが、他の形式を直接入力することも可能です。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "ファイル"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1176,10 +1172,6 @@ msgstr "アップデートに失敗しました: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "パッケージをアップデート中"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "アップロード"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -288,7 +288,7 @@ msgstr "カスタム"
 msgid "Name"
 msgstr "名前"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "サイズ"
 
@@ -312,7 +312,7 @@ msgstr "既存の「%s」を置き換えます。"
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr ".woff2 フォントをここにドラッグするか、クリックして選択してください"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "アップロードを確定"
 
@@ -320,11 +320,11 @@ msgstr "アップロードを確定"
 msgid "Custom Fonts"
 msgstr "カスタムフォント"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "対応していないファイル形式です。対応形式: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "ファイルサイズが %s で、8MB の上限を超えています。"
 
@@ -366,9 +366,7 @@ msgstr ""
 "見出し、本文テキスト、アイコン、およびフォーム値のデフォルトのフォアグラウン"
 "ド（前景）色。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "削除"
 
@@ -1178,12 +1176,11 @@ msgstr ""
 "て管理します。ファイルは <code>/www/luci-static/aurora/images/</code> に保存"
 "されます。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "アップロードに失敗しました"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "アップロードに失敗しました (HTTP %s)"
 

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -288,6 +288,7 @@ msgstr "カスタム"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "カスタムフォント"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "名前"
@@ -308,6 +309,9 @@ msgstr "ファイル名(拡張子を含む)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "login-bg.* という名前にすると、ログインページの背景として使用されます。"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "既存の「%s」を置き換えます。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -326,8 +326,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "「%s」を削除しますか?インターフェイスは既定のフォントに戻ります。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "カスタムフォントはルーターの限られたフラッシュストレージに保存され、各ブラウザーの初回読み込み時にダウンロードされます。CJK フォントの場合は、必要なグリフのみを含むサブセット化した .woff2 を使用すると、容量を節約し読み込みを高速化できます。"
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "カスタムフォントのファイルは、ルーターの限られたフラッシュストレージに保存されるため、できるだけ小さくしてください。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -301,6 +301,10 @@ msgstr "カスタム"
 msgid "Custom Fonts"
 msgstr "カスタムフォント"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "カスタムフォントはルーターの限られたフラッシュストレージに保存され、各ブラウザーの初回読み込み時にダウンロードされます。CJK フォントの場合は、必要なグリフのみを含むサブセット化した .woff2 を使用すると、容量を節約し読み込みを高速化できます。"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "危険"
@@ -756,8 +760,8 @@ msgid "On-Brand Text"
 msgstr "ブランドカラー上のテキスト"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "4MB までの .woff2 ファイルのみ使用できます。"
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "8MB までの .woff2 ファイルのみ使用できます。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -284,11 +284,6 @@ msgstr "角丸の半径"
 msgid "Custom"
 msgstr "カスタム"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "カスタムフォント"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "名前"
@@ -344,6 +339,10 @@ msgstr "「%s」を削除しますか?インターフェイスは既定のフォ
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "カスタムフォントのファイルは、ルーターの限られたフラッシュストレージに保存されるため、できるだけ小さくしてください。"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "フォントライブラリ"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -47,10 +47,6 @@ msgstr ""
 "通知、バリデーション、およびステータスフィードバックのためのアクセントカ"
 "ラー。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "アクション"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -114,10 +110,6 @@ msgid ""
 msgstr ""
 "本当に <strong>%h</strong> をバージョン <strong>%h</strong> にアップデートし"
 "ますか？"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "アセットファイル名"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -296,6 +288,26 @@ msgstr "カスタム"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "カスタムフォント"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "名前"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "サイズ"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "種類"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "ファイル名(拡張子を含む)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "login-bg.* という名前にすると、ログインページの背景として使用されます。"
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -473,10 +485,6 @@ msgstr "削除に失敗しました: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "かすかなホバー"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "フォント名"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -828,10 +836,6 @@ msgstr "プリセット"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "プリセットが正常に適用されました。"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "プレビュー"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/ja/aurora-config.po
+++ b/po/ja/aurora-config.po
@@ -317,6 +317,10 @@ msgid "Confirm Upload"
 msgstr "アップロードを確定"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "カスタムフォント"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "ファイルを削除"
 

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -307,10 +307,6 @@ msgid "Custom Fonts"
 msgstr "사용자 지정 글꼴"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "파일 제거"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "지원하지 않는 파일 형식입니다. 허용: %s"
 

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -270,11 +270,6 @@ msgstr "모서리 둥글기"
 msgid "Custom"
 msgstr "사용자 지정"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "사용자 지정 글꼴"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "이름"
@@ -330,6 +325,10 @@ msgstr "'%s'을(를) 삭제할까요? 인터페이스는 기본 글꼴로 되돌
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "사용자 지정 글꼴 파일은 라우터의 제한된 플래시 저장소에 저장되므로 가능한 한 작게 유지하세요."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "글꼴 라이브러리"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -274,7 +274,7 @@ msgstr "사용자 지정"
 msgid "Name"
 msgstr "이름"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "크기"
 
@@ -298,7 +298,7 @@ msgstr "기존 '%s'을(를) 대체합니다."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr ".woff2 글꼴을 여기에 끌어다 놓거나 클릭하여 선택하세요"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "업로드 확인"
 
@@ -306,11 +306,11 @@ msgstr "업로드 확인"
 msgid "Custom Fonts"
 msgstr "사용자 지정 글꼴"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "지원하지 않는 파일 형식입니다. 허용: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "파일 크기가 %s로 8MB 제한을 초과합니다."
 
@@ -350,9 +350,7 @@ msgstr "기본값"
 msgid "Default foreground for headings, body text, icons, and form values."
 msgstr "제목, 본문 텍스트, 아이콘 및 폼 값에 대한 기본 전경색."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "삭제"
 
@@ -1142,12 +1140,11 @@ msgstr ""
 "아이콘, 파비콘, PWA 자산 및 로그인 배경용 이미지를 업로드하고 관리합니다. 파"
 "일은 <code>/www/luci-static/aurora/images/</code>에 저장됩니다."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "업로드 실패"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "업로드 실패 (HTTP %s)"
 

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -476,10 +476,6 @@ msgstr ""
 "필드는 #hex, rgb(), hsl(), lab(), oklch()를 지원합니다. 선택기는 hex를 채우"
 "며, 다른 형식은 직접 입력할 수 있습니다."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "파일"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr "폼 컨트롤(입력란, 선택 상자, 텍스트 영역, 체크박스)의 채우기 색상."
@@ -1140,10 +1136,6 @@ msgstr "업데이트 실패: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "패키지 업데이트 중"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "업로드"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -230,10 +230,6 @@ msgstr "업데이트 확인 중..."
 msgid "Checking..."
 msgstr "확인 중..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr ".woff2 파일을 선택하고 글꼴 이름을 입력하세요"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "이 토큰에 사용할 정확한 색상을 선택하세요"
@@ -286,6 +282,34 @@ msgstr "사용자 지정"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "사용자 지정 글꼴"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr ".woff2 글꼴을 여기에 끌어다 놓거나 클릭하여 선택하세요"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "업로드 확인"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "파일 제거"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "지원하지 않는 파일 형식입니다. 허용: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "파일 크기가 %s로 8MB 제한을 초과합니다."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "사용자 지정 글꼴 삭제"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "'%s'을(를) 삭제할까요? 인터페이스는 기본 글꼴로 되돌아갑니다."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -600,8 +624,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "유효하지 않거나, 누락되었거나, 순환 참조되는 색상 표현식입니다."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1120,11 +1144,6 @@ msgstr "패키지 업데이트 중"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "업로드"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "사용자 지정 글꼴 업로드"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -41,10 +41,6 @@ msgstr "경고, 주의 사항 및 유효성 검사 메시지를 위한 강조색
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "알림, 유효성 검사 및 상태 피드백을 위한 강조색."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "작업"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -106,10 +102,6 @@ msgid ""
 msgstr ""
 "정말로 <strong>%h</strong>을(를) 버전 <strong>%h</strong>(으)로 업데이트하시"
 "겠습니까?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "자산 파일명"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -282,6 +274,26 @@ msgstr "사용자 지정"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "사용자 지정 글꼴"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "이름"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "크기"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "유형"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "파일 이름(확장자 포함)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "login-bg.*로 이름을 지정하면 로그인 페이지 배경으로 사용됩니다."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -455,10 +467,6 @@ msgstr "삭제 실패: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "흐릿한 호버"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "글꼴 이름"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -796,10 +804,6 @@ msgstr "프리셋"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "프리셋이 성공적으로 적용되었습니다."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "미리보기"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -312,8 +312,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "'%s'을(를) 삭제할까요? 인터페이스는 기본 글꼴로 되돌아갑니다."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "사용자 지정 글꼴은 라우터의 제한된 플래시 저장소에 저장되며 각 브라우저에서 처음 불러올 때 다운로드됩니다. CJK 글꼴은 필요한 글리프만 포함한 서브셋 .woff2를 사용하면 공간을 절약하고 로딩 속도를 높일 수 있습니다."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "사용자 지정 글꼴 파일은 라우터의 제한된 플래시 저장소에 저장되므로 가능한 한 작게 유지하세요."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -303,6 +303,10 @@ msgid "Confirm Upload"
 msgstr "업로드 확인"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "사용자 지정 글꼴"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "파일 제거"
 

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -894,14 +894,8 @@ msgid "Sans-Serif Typeface"
 msgstr "고딕체 서체"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"테마 전체에서 사용하는 산세리프 및 고정폭 글꼴입니다. 웹 글꼴은 버전이 고정되"
-"고 체크섬이 검증된 소스에서 한 번만 내려받아 로컬에서 제공되며, 페이지가 인터"
-"넷에서 글꼴을 불러오는 일은 없습니다."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "테마 전체에서 사용하는 산세리프 및 고정폭 글꼴입니다. 엄선된 웹 글꼴(저장 후 버전이 고정되고 체크섬이 검증된 소스에서 한 번만 내려받아 이후 로컬에서 제공)을 선택하거나 자신의 .woff2 파일을 업로드할 수 있습니다."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -326,10 +326,6 @@ msgstr "'%s'을(를) 삭제할까요? 인터페이스는 기본 글꼴로 되돌
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "사용자 지정 글꼴 파일은 라우터의 제한된 플래시 저장소에 저장되므로 가능한 한 작게 유지하세요."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "글꼴 라이브러리"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "위험"

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -287,6 +287,10 @@ msgstr "사용자 지정"
 msgid "Custom Fonts"
 msgstr "사용자 지정 글꼴"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "사용자 지정 글꼴은 라우터의 제한된 플래시 저장소에 저장되며 각 브라우저에서 처음 불러올 때 다운로드됩니다. CJK 글꼴은 필요한 글리프만 포함한 서브셋 .woff2를 사용하면 공간을 절약하고 로딩 속도를 높일 수 있습니다."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "위험"
@@ -726,8 +730,8 @@ msgid "On-Brand Text"
 msgstr "브랜드 배경 위 텍스트"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "4MB 이하의 .woff2 파일만 사용할 수 있습니다."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "8MB 이하의 .woff2 파일만 사용할 수 있습니다."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/ko/aurora-config.po
+++ b/po/ko/aurora-config.po
@@ -274,6 +274,7 @@ msgstr "사용자 지정"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "사용자 지정 글꼴"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "이름"
@@ -294,6 +295,9 @@ msgstr "파일 이름(확장자 포함)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "login-bg.*로 이름을 지정하면 로그인 페이지 배경으로 사용됩니다."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "기존 '%s'을(를) 대체합니다."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -313,10 +313,6 @@ msgid "Custom Fonts"
 msgstr "Aangepaste lettertypen"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Bestand verwijderen"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Niet-ondersteund bestandstype. Toegestaan: %s"
 

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -318,8 +318,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "'%s' verwijderen? De interface valt terug op het standaardlettertype."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Aangepaste lettertypen worden opgeslagen in de beperkte flash-opslag van de router en door elke browser bij het eerste laden gedownload. Gebruik voor CJK-lettertypen bij voorkeur een .woff2 met alleen de benodigde glyphs, om ruimte te besparen en sneller te laden."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Houd aangepaste lettertypebestanden zo klein mogelijk, omdat ze worden opgeslagen in de beperkte flash-opslag van de router."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -276,11 +276,6 @@ msgstr "Hoekstraal"
 msgid "Custom"
 msgstr "Aangepast"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Aangepaste lettertypen"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Naam"
@@ -336,6 +331,10 @@ msgstr "'%s' verwijderen? De interface valt terug op het standaardlettertype."
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Houd aangepaste lettertypebestanden zo klein mogelijk, omdat ze worden opgeslagen in de beperkte flash-opslag van de router."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Lettertypebibliotheek"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -293,6 +293,10 @@ msgstr "Aangepast"
 msgid "Custom Fonts"
 msgstr "Aangepaste lettertypen"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Aangepaste lettertypen worden opgeslagen in de beperkte flash-opslag van de router en door elke browser bij het eerste laden gedownload. Gebruik voor CJK-lettertypen bij voorkeur een .woff2 met alleen de benodigde glyphs, om ruimte te besparen en sneller te laden."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Gevaar"
@@ -748,8 +752,8 @@ msgid "On-Brand Text"
 msgstr "Tekst in merk-kleur"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Alleen .woff2-bestanden tot 4 MB worden geaccepteerd."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Alleen .woff2-bestanden tot 8 MB worden geaccepteerd."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -280,6 +280,7 @@ msgstr "Aangepast"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Aangepaste lettertypen"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Naam"
@@ -300,6 +301,9 @@ msgstr "Bestandsnaam (met extensie)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Geef het de naam login-bg.* om het als achtergrond van de inlogpagina te gebruiken."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Vervangt het bestaande bestand '%s'."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -487,10 +487,6 @@ msgstr ""
 "Velden accepteren #hex, rgb(), hsl(), lab() en oklch(). De kiezer vult hex "
 "in; andere formaten kunnen worden getypt."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Bestand"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1166,10 +1162,6 @@ msgstr "Bijwerken mislukt: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Pakket bijwerken..."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Uploaden"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -236,10 +236,6 @@ msgstr "Controleren op updates..."
 msgid "Checking..."
 msgstr "Controleren..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Kies een .woff2-bestand en vul een lettertypenaam in"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Kies een exacte kleur voor dit token"
@@ -292,6 +288,34 @@ msgstr "Aangepast"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Aangepaste lettertypen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Sleep een .woff2-lettertype hierheen of klik om te bladeren"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Upload bevestigen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Bestand verwijderen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Niet-ondersteund bestandstype. Toegestaan: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Het bestand is %s en overschrijdt de limiet van 8 MB."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Aangepast lettertype verwijderen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "'%s' verwijderen? De interface valt terug op het standaardlettertype."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -620,8 +644,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Ongeldige, ontbrekende of cyclische kleuruitdrukking."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1146,11 +1170,6 @@ msgstr "Pakket bijwerken..."
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Uploaden"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Aangepast lettertype uploaden"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -42,10 +42,6 @@ msgstr "Accent voor waarschuwingen, opmerkingen en validatieberichten."
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Accenten voor meldingen, validatie en statusfeedback."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Acties"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -107,10 +103,6 @@ msgid ""
 msgstr ""
 "Weet u zeker dat u <strong>%h</strong> wilt bijwerken naar versie "
 "<strong>%h</strong>?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Bestandsnaam van asset"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -288,6 +280,26 @@ msgstr "Aangepast"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Aangepaste lettertypen"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Naam"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Grootte"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Type"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Bestandsnaam (met extensie)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Geef het de naam login-bg.* om het als achtergrond van de inlogpagina te gebruiken."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -466,10 +478,6 @@ msgstr "Verwijderen mislukt: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Lichte hover"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Lettertypenaam"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -821,10 +829,6 @@ msgstr "Preset"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Preset succesvol toegepast."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Voorbeeld"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -280,7 +280,7 @@ msgstr "Aangepast"
 msgid "Name"
 msgstr "Naam"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Grootte"
 
@@ -304,7 +304,7 @@ msgstr "Vervangt het bestaande bestand '%s'."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Sleep een .woff2-lettertype hierheen of klik om te bladeren"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Upload bevestigen"
 
@@ -312,11 +312,11 @@ msgstr "Upload bevestigen"
 msgid "Custom Fonts"
 msgstr "Aangepaste lettertypen"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Niet-ondersteund bestandstype. Toegestaan: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Het bestand is %s en overschrijdt de limiet van 8 MB."
 
@@ -358,9 +358,7 @@ msgstr ""
 "Domyślny kolor pierwszego planu dla nagłówków, tekstu głównego, ikon i "
 "wartości formularzy."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -1169,12 +1167,11 @@ msgstr ""
 "achtergrond. Bestanden worden opgeslagen in <code>/www/luci-static/aurora/"
 "images/</code>."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Uploaden mislukt"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Uploaden mislukt (HTTP %s)"
 

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -332,10 +332,6 @@ msgstr "'%s' verwijderen? De interface valt terug op het standaardlettertype."
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Houd aangepaste lettertypebestanden zo klein mogelijk, omdat ze worden opgeslagen in de beperkte flash-opslag van de router."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Lettertypebibliotheek"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Gevaar"

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -920,14 +920,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Sans-serif lettertype"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Schreefloze en monospace-lettertypen voor het hele thema. Webfonts worden "
-"eenmalig gedownload van bronnen met vaste versie en checksumverificatie en "
-"lokaal geserveerd; pagina's laden nooit lettertypen van internet."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Schreefloze en monospace-lettertypen voor het hele thema. Kies een geselecteerd webfont — na het opslaan eenmalig gedownload van bronnen met vaste versie en checksumverificatie, daarna lokaal geserveerd — of upload uw eigen .woff2-bestanden."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/nl/aurora-config.po
+++ b/po/nl/aurora-config.po
@@ -309,6 +309,10 @@ msgid "Confirm Upload"
 msgstr "Upload bevestigen"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Aangepaste lettertypen"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Bestand verwijderen"
 

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -931,15 +931,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Krój pisma bezszeryfowy"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Czcionki bezszeryfowe i o stałej szerokości używane w całym motywie. "
-"Czcionki webowe są pobierane jednorazowo ze źródeł o przypiętej wersji, "
-"zweryfikowanych sumą kontrolną, i serwowane lokalnie; strony nigdy nie "
-"ładują czcionek z internetu."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Czcionki bezszeryfowe i o stałej szerokości używane w całym motywie. Wybierz starannie dobraną czcionkę webową — pobieraną jednorazowo po zapisaniu, ze źródeł o przypiętej wersji, zweryfikowanych sumą kontrolną, a następnie serwowaną lokalnie — lub prześlij własne pliki .woff2."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -284,6 +284,7 @@ msgstr "Własne"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Własne czcionki"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nazwa"
@@ -304,6 +305,9 @@ msgstr "Nazwa pliku (z rozszerzeniem)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Nazwij go login-bg.*, aby użyć go jako tła strony logowania."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Zastąpi istniejący plik „%s”."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -322,8 +322,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "Usunąć „%s”? Interfejs wróci do domyślnej czcionki."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Własne czcionki są przechowywane w ograniczonej pamięci flash routera i pobierane przez każdą przeglądarkę przy pierwszym załadowaniu. W przypadku czcionek CJK zalecany jest plik .woff2 zawierający tylko potrzebne glify, aby zaoszczędzić miejsce i przyspieszyć ładowanie."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Pliki własnych czcionek powinny być jak najmniejsze, ponieważ są przechowywane w ograniczonej pamięci flash routera."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -317,10 +317,6 @@ msgid "Custom Fonts"
 msgstr "Własne czcionki"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Usuń plik"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Nieobsługiwany typ pliku. Dozwolone: %s"
 

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -336,10 +336,6 @@ msgstr "Usunąć „%s”? Interfejs wróci do domyślnej czcionki."
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Pliki własnych czcionek powinny być jak najmniejsze, ponieważ są przechowywane w ograniczonej pamięci flash routera."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Biblioteka czcionek"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Niebezpieczeństwo"

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -491,10 +491,6 @@ msgstr ""
 "Pola akceptują formaty #hex, rgb(), hsl(), lab() i oklch(). Próbnik "
 "uzupełnia hex; inne formaty można wpisać ręcznie."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Plik"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1179,10 +1175,6 @@ msgstr "Aktualizacja nie powiodła się: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Aktualizowanie pakietu"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Prześlij"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -284,7 +284,7 @@ msgstr "Własne"
 msgid "Name"
 msgstr "Nazwa"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Rozmiar"
 
@@ -308,7 +308,7 @@ msgstr "Zastąpi istniejący plik „%s”."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Przeciągnij tutaj czcionkę .woff2 lub kliknij, aby wybrać"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Potwierdź przesyłanie"
 
@@ -316,11 +316,11 @@ msgstr "Potwierdź przesyłanie"
 msgid "Custom Fonts"
 msgstr "Własne czcionki"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Nieobsługiwany typ pliku. Dozwolone: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Plik ma %s i przekracza limit 8 MB."
 
@@ -362,9 +362,7 @@ msgstr ""
 "Domyślny kolor pierwszego planu dla nagłówków, tekstu głównego, ikon i "
 "wartości formularzy."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Usuń"
 
@@ -1180,12 +1178,11 @@ msgstr ""
 "Przesyłaj i zarządzaj obrazami ikon, faviconów, zasobów PWA i tła logowania. "
 "Pliki są przechowywane w <code>/www/luci-static/aurora/images/</code>."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Przesyłanie nie powiodło się"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Przesyłanie nie powiodło się (HTTP %s)"
 

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -42,10 +42,6 @@ msgstr "Akcent dla ostrzeżeń, powiadomień i komunikatów walidacji."
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Akcenty dla powiadomień, walidacji i informacji zwrotnych o stanie."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Akcje"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -108,10 +104,6 @@ msgid ""
 msgstr ""
 "Czy na pewno chcesz zaktualizować <strong>%h</strong> do wersji <strong>%h</"
 "strong>?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Nazwa pliku zasobu"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -292,6 +284,26 @@ msgstr "Własne"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Własne czcionki"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Nazwa"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Rozmiar"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Typ"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Nazwa pliku (z rozszerzeniem)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Nazwij go login-bg.*, aby użyć go jako tła strony logowania."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -470,10 +482,6 @@ msgstr "Nie udało się usunąć: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Subtelne najechanie"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Nazwa czcionki"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -832,10 +840,6 @@ msgstr "Preset"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Preset zastosowany pomyślnie."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Podgląd"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -280,11 +280,6 @@ msgstr "Promień zaokrąglenia rogów"
 msgid "Custom"
 msgstr "Własne"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Własne czcionki"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Nazwa"
@@ -340,6 +335,10 @@ msgstr "Usunąć „%s”? Interfejs wróci do domyślnej czcionki."
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Pliki własnych czcionek powinny być jak najmniejsze, ponieważ są przechowywane w ograniczonej pamięci flash routera."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Biblioteka czcionek"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -297,6 +297,10 @@ msgstr "Własne"
 msgid "Custom Fonts"
 msgstr "Własne czcionki"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Własne czcionki są przechowywane w ograniczonej pamięci flash routera i pobierane przez każdą przeglądarkę przy pierwszym załadowaniu. W przypadku czcionek CJK zalecany jest plik .woff2 zawierający tylko potrzebne glify, aby zaoszczędzić miejsce i przyspieszyć ładowanie."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Niebezpieczeństwo"
@@ -760,8 +764,8 @@ msgid "On-Brand Text"
 msgstr "Tekst w kolorze marki"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Akceptowane są tylko pliki .woff2 do 4 MB."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Akceptowane są tylko pliki .woff2 do 8 MB."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -313,6 +313,10 @@ msgid "Confirm Upload"
 msgstr "Potwierdź przesyłanie"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Własne czcionki"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Usuń plik"
 

--- a/po/pl/aurora-config.po
+++ b/po/pl/aurora-config.po
@@ -240,10 +240,6 @@ msgstr "Sprawdzanie aktualizacji..."
 msgid "Checking..."
 msgstr "Sprawdzanie..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Wybierz plik .woff2 i podaj nazwę czcionki"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Wybierz dosłowny kolor dla tego tokenu"
@@ -296,6 +292,34 @@ msgstr "Własne"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Własne czcionki"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Przeciągnij tutaj czcionkę .woff2 lub kliknij, aby wybrać"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Potwierdź przesyłanie"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Usuń plik"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Nieobsługiwany typ pliku. Dozwolone: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Plik ma %s i przekracza limit 8 MB."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Usuń własną czcionkę"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "Usunąć „%s”? Interfejs wróci do domyślnej czcionki."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -632,8 +656,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Niepoprawne, brakujące lub zapętlone wyrażenie koloru."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1159,11 +1183,6 @@ msgstr "Aktualizowanie pakietu"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Prześlij"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Prześlij własną czcionkę"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -338,10 +338,6 @@ msgstr "Удалить «%s»? Интерфейс вернётся к шрифт
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Файлы пользовательских шрифтов должны быть как можно меньше, так как они хранятся в ограниченной флеш-памяти роутера."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Библиотека шрифтов"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Опасность"

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -282,11 +282,6 @@ msgstr "Радиус скругления углов"
 msgid "Custom"
 msgstr "Пользовательский"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Пользовательские шрифты"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Название"
@@ -342,6 +337,10 @@ msgstr "Удалить «%s»? Интерфейс вернётся к шрифт
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Файлы пользовательских шрифтов должны быть как можно меньше, так как они хранятся в ограниченной флеш-памяти роутера."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Библиотека шрифтов"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -299,6 +299,10 @@ msgstr "Пользовательский"
 msgid "Custom Fonts"
 msgstr "Пользовательские шрифты"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Пользовательские шрифты хранятся в ограниченной флеш-памяти роутера и загружаются каждым браузером при первом открытии. Для шрифтов CJK предпочтительно использовать .woff2 с подмножеством, содержащим только нужные глифы, чтобы сэкономить место и ускорить загрузку."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Опасность"
@@ -755,8 +759,8 @@ msgid "On-Brand Text"
 msgstr "Текст на фоне бренда"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Принимаются только файлы .woff2 размером до 4 МБ."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Принимаются только файлы .woff2 размером до 8 МБ."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -324,8 +324,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "Удалить «%s»? Интерфейс вернётся к шрифту по умолчанию."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Пользовательские шрифты хранятся в ограниченной флеш-памяти роутера и загружаются каждым браузером при первом открытии. Для шрифтов CJK предпочтительно использовать .woff2 с подмножеством, содержащим только нужные глифы, чтобы сэкономить место и ускорить загрузку."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Файлы пользовательских шрифтов должны быть как можно меньше, так как они хранятся в ограниченной флеш-памяти роутера."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -43,10 +43,6 @@ msgstr "Акцент для предупреждений, уведомлений
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Акценты для уведомлений, валидации и обратной связи о состоянии."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Действия"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -111,10 +107,6 @@ msgid ""
 msgstr ""
 "Вы уверены, что хотите обновить <strong>%h</strong> до версии <strong>%h</"
 "strong>?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Имя файла ресурса"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -294,6 +286,26 @@ msgstr "Пользовательский"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Пользовательские шрифты"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Название"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Размер"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Тип"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Имя файла (с расширением)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Назовите файл login-bg.*, чтобы использовать его как фон страницы входа."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -471,10 +483,6 @@ msgstr "Не удалось удалить: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Слабое наведение"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Название шрифта"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -825,10 +833,6 @@ msgstr "Пресет"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Пресет успешно применен."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Предпросмотр"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -286,7 +286,7 @@ msgstr "Пользовательский"
 msgid "Name"
 msgstr "Название"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Размер"
 
@@ -310,7 +310,7 @@ msgstr "Заменит существующий файл «%s»."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Перетащите шрифт .woff2 сюда или нажмите, чтобы выбрать"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Подтвердить загрузку"
 
@@ -318,11 +318,11 @@ msgstr "Подтвердить загрузку"
 msgid "Custom Fonts"
 msgstr "Пользовательские шрифты"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Неподдерживаемый тип файла. Допустимые: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Размер файла %s, что превышает лимит 8 МБ."
 
@@ -364,9 +364,7 @@ msgstr ""
 "Основной цвет переднего плана для заголовков, основного текста, иконок и "
 "значений форм."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Удалить"
 
@@ -1174,12 +1172,11 @@ msgstr ""
 "входа и управляйте ими. Файлы хранятся в <code>/www/luci-static/aurora/"
 "images/</code>."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Ошибка загрузки"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Ошибка загрузки (HTTP %s)"
 

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -319,10 +319,6 @@ msgid "Custom Fonts"
 msgstr "Пользовательские шрифты"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Убрать файл"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Неподдерживаемый тип файла. Допустимые: %s"
 

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -242,10 +242,6 @@ msgstr "Проверка обновлений..."
 msgid "Checking..."
 msgstr "Проверка..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Выберите файл .woff2 и укажите название шрифта"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Выберите точный цвет для этого токена"
@@ -298,6 +294,34 @@ msgstr "Пользовательский"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Пользовательские шрифты"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Перетащите шрифт .woff2 сюда или нажмите, чтобы выбрать"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Подтвердить загрузку"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Убрать файл"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Неподдерживаемый тип файла. Допустимые: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Размер файла %s, что превышает лимит 8 МБ."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Удалить пользовательский шрифт"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "Удалить «%s»? Интерфейс вернётся к шрифту по умолчанию."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -627,8 +651,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Неверное, отсутствующее или циклическое цветовое выражение."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1152,11 +1176,6 @@ msgstr "Обновление пакета"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Загрузить"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Загрузить пользовательский шрифт"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -492,10 +492,6 @@ msgstr ""
 "Поля принимают #hex, rgb(), hsl(), lab() и oklch(). Пипетка подставляет hex; "
 "остальные форматы можно ввести вручную."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Файл"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1172,10 +1168,6 @@ msgstr "Ошибка обновления: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Обновление пакета"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Загрузить"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -286,6 +286,7 @@ msgstr "Пользовательский"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Пользовательские шрифты"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Название"
@@ -306,6 +307,9 @@ msgstr "Имя файла (с расширением)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Назовите файл login-bg.*, чтобы использовать его как фон страницы входа."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Заменит существующий файл «%s»."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -924,15 +924,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Шрифт без засечек"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Шрифты без засечек и моноширинные, используемые во всей теме. Веб-шрифты "
-"скачиваются один раз из источников с фиксированной версией и проверкой "
-"контрольной суммы и раздаются локально; страницы никогда не загружают шрифты "
-"из интернета."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Шрифты без засечек и моноширинные, используемые во всей теме. Выберите подобранный веб-шрифт — он скачивается один раз после сохранения из источников с фиксированной версией и проверкой контрольной суммы, а затем раздаётся локально — или загрузите собственные файлы .woff2."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/ru/aurora-config.po
+++ b/po/ru/aurora-config.po
@@ -315,6 +315,10 @@ msgid "Confirm Upload"
 msgstr "Подтвердить загрузку"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Пользовательские шрифты"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Убрать файл"
 

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -220,10 +220,6 @@ msgstr ""
 msgid "Checking..."
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr ""
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr ""
@@ -275,6 +271,34 @@ msgstr ""
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
@@ -580,7 +604,7 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
@@ -1078,11 +1102,6 @@ msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
-msgstr ""
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -297,10 +297,6 @@ msgid "Custom Fonts"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr ""
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr ""
 

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -302,7 +302,7 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -316,10 +316,6 @@ msgstr ""
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr ""
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr ""

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -459,10 +459,6 @@ msgid ""
 "other formats can be typed."
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr ""
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1098,10 +1094,6 @@ msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
-msgstr ""
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -866,10 +866,7 @@ msgid "Sans-Serif Typeface"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -264,6 +264,7 @@ msgstr ""
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr ""
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr ""
@@ -284,6 +285,9 @@ msgstr ""
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr ""
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -41,10 +41,6 @@ msgstr ""
 msgid "Accents for notifications, validation, and status feedback."
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr ""
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -99,10 +95,6 @@ msgstr ""
 msgid ""
 "Are you sure you want to update <strong>%h</strong> to version <strong>%h</"
 "strong>?"
-msgstr ""
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
@@ -272,6 +264,26 @@ msgstr ""
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr ""
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr ""
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -439,10 +451,6 @@ msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
-msgstr ""
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
@@ -772,10 +780,6 @@ msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
-msgstr ""
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -264,7 +264,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgstr ""
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr ""
 
@@ -296,11 +296,11 @@ msgstr ""
 msgid "Custom Fonts"
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr ""
 
@@ -340,9 +340,7 @@ msgstr ""
 msgid "Default foreground for headings, body text, icons, and form values."
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr ""
 
@@ -1102,12 +1100,11 @@ msgid ""
 "background. Files are stored in <code>/www/luci-static/aurora/images/</code>."
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr ""
 

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -260,11 +260,6 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr ""
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr ""
@@ -319,6 +314,10 @@ msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -293,6 +293,10 @@ msgid "Confirm Upload"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr ""
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr ""
 

--- a/po/templates/aurora-config.pot
+++ b/po/templates/aurora-config.pot
@@ -277,6 +277,10 @@ msgstr ""
 msgid "Custom Fonts"
 msgstr ""
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr ""
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr ""
@@ -703,7 +707,7 @@ msgid "On-Brand Text"
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
+msgid "Only .woff2 files up to 8MB are accepted."
 msgstr ""
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -331,10 +331,6 @@ msgstr "“%s” silinsin mi? Arayüz varsayılan yazı tipine döner."
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Özel yazı tipi dosyalarını olabildiğince küçük tutun; yönlendiricinin sınırlı flash depolamasında saklanırlar."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Yazı Tipi Kitaplığı"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Tehlike"

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -292,6 +292,10 @@ msgstr "Özel"
 msgid "Custom Fonts"
 msgstr "Özel Yazı Tipleri"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Özel yazı tipleri yönlendiricinin sınırlı flash depolamasında saklanır ve her tarayıcı tarafından ilk yüklemede indirilir. CJK yazı tipleri için yalnızca gereken glifleri içeren alt küme bir .woff2 tercih edin; böylece yerden tasarruf eder ve daha hızlı yüklenir."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Tehlike"
@@ -741,8 +745,8 @@ msgid "On-Brand Text"
 msgstr "Marka Üzeri Metin"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Yalnızca 4 MB'a kadar .woff2 dosyaları kabul edilir."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Yalnızca 8 MB'a kadar .woff2 dosyaları kabul edilir."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -42,10 +42,6 @@ msgstr "Uyarılar, bildirimler ve doğrulama mesajları için vurgu rengi."
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Bildirimler, doğrulama ve durum geri bildirimleri için vurgu renkleri."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Eylemler"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -108,10 +104,6 @@ msgid ""
 msgstr ""
 "<strong>%h</strong> sürümünü <strong>%h</strong> sürümüne güncellemek "
 "istediğinizden emin misiniz?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Varlık Dosya Adı"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -287,6 +279,26 @@ msgstr "Özel"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Özel Yazı Tipleri"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Ad"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Boyut"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Tür"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Dosya adı (uzantı dahil)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Giriş sayfası arka planı olarak kullanmak için login-bg.* olarak adlandırın."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -463,10 +475,6 @@ msgstr "Silme başarısız oldu: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Hafif Üzerine Gelme"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Yazı tipi adı"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -812,10 +820,6 @@ msgstr "Hazır Ayar"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Hazır ayar başarıyla uygulandı."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Önizleme"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -275,11 +275,6 @@ msgstr "Köşe Yarıçapı"
 msgid "Custom"
 msgstr "Özel"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Özel Yazı Tipleri"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Ad"
@@ -335,6 +330,10 @@ msgstr "“%s” silinsin mi? Arayüz varsayılan yazı tipine döner."
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Özel yazı tipi dosyalarını olabildiğince küçük tutun; yönlendiricinin sınırlı flash depolamasında saklanırlar."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Yazı Tipi Kitaplığı"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -911,15 +911,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Sans-Serif Yazı Tipi"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Tema genelinde kullanılan sans-serif ve eş aralıklı yazı tipleri. Web yazı "
-"tipleri, sürümü sabitlenmiş ve sağlama toplamı doğrulanmış kaynaklardan "
-"yalnızca bir kez indirilir ve yerel olarak sunulur; sayfalar hiçbir zaman "
-"internetten yazı tipi yüklemez."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Tema genelinde kullanılan sans-serif ve eş aralıklı yazı tipleri. Kaydettikten sonra, sürümü sabitlenmiş ve sağlama toplamı doğrulanmış kaynaklardan yalnızca bir kez indirilip ardından yerel olarak sunulan seçilmiş bir web yazı tipi seçin veya kendi .woff2 dosyalarınızı yükleyin."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -484,10 +484,6 @@ msgstr ""
 "Alanlar #hex, rgb(), hsl(), lab() ve oklch() formatlarını kabul eder. Seçici "
 "hex formatını doldurur; diğer formatlar manuel yazılabilir."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Dosya"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1159,10 +1155,6 @@ msgstr "Güncelleme başarısız oldu: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Paket Güncelleniyor"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Yükle"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -308,6 +308,10 @@ msgid "Confirm Upload"
 msgstr "Yüklemeyi Onayla"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Özel Yazı Tipleri"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Dosyayı kaldır"
 

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -317,8 +317,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "“%s” silinsin mi? Arayüz varsayılan yazı tipine döner."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Özel yazı tipleri yönlendiricinin sınırlı flash depolamasında saklanır ve her tarayıcı tarafından ilk yüklemede indirilir. CJK yazı tipleri için yalnızca gereken glifleri içeren alt küme bir .woff2 tercih edin; böylece yerden tasarruf eder ve daha hızlı yüklenir."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Özel yazı tipi dosyalarını olabildiğince küçük tutun; yönlendiricinin sınırlı flash depolamasında saklanırlar."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -235,10 +235,6 @@ msgstr "Güncellemeler denetleniyor..."
 msgid "Checking..."
 msgstr "Denetleniyor..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Bir .woff2 dosyası seçin ve yazı tipi adı girin"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Bu token için tam bir renk seçin"
@@ -291,6 +287,34 @@ msgstr "Özel"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Özel Yazı Tipleri"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr ".woff2 yazı tipini buraya sürükleyin veya seçmek için tıklayın"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Yüklemeyi Onayla"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Dosyayı kaldır"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Desteklenmeyen dosya türü. İzin verilenler: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Dosya %s boyutunda ve 8 MB sınırını aşıyor."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Özel Yazı Tipini Sil"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "“%s” silinsin mi? Arayüz varsayılan yazı tipine döner."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -614,8 +638,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Geçersiz, eksik veya döngüsel renk ifadesi."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1139,11 +1163,6 @@ msgstr "Paket Güncelleniyor"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Yükle"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Özel Yazı Tipi Yükle"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -312,10 +312,6 @@ msgid "Custom Fonts"
 msgstr "Özel Yazı Tipleri"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Dosyayı kaldır"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Desteklenmeyen dosya türü. İzin verilenler: %s"
 

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -279,6 +279,7 @@ msgstr "Özel"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Özel Yazı Tipleri"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Ad"
@@ -299,6 +300,9 @@ msgstr "Dosya adı (uzantı dahil)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Giriş sayfası arka planı olarak kullanmak için login-bg.* olarak adlandırın."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Mevcut “%s” dosyasının yerini alacak."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/tr/aurora-config.po
+++ b/po/tr/aurora-config.po
@@ -279,7 +279,7 @@ msgstr "Özel"
 msgid "Name"
 msgstr "Ad"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Boyut"
 
@@ -303,7 +303,7 @@ msgstr "Mevcut “%s” dosyasının yerini alacak."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr ".woff2 yazı tipini buraya sürükleyin veya seçmek için tıklayın"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Yüklemeyi Onayla"
 
@@ -311,11 +311,11 @@ msgstr "Yüklemeyi Onayla"
 msgid "Custom Fonts"
 msgstr "Özel Yazı Tipleri"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Desteklenmeyen dosya türü. İzin verilenler: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Dosya %s boyutunda ve 8 MB sınırını aşıyor."
 
@@ -356,9 +356,7 @@ msgid "Default foreground for headings, body text, icons, and form values."
 msgstr ""
 "Başlıklar, gövde metni, simgeler ve form değerleri için varsayılan ön plan."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Sil"
 
@@ -1161,12 +1159,11 @@ msgstr ""
 "yükleyin ve yönetin. Dosyalar <code>/www/luci-static/aurora/images/</code> "
 "dizininde saklanır."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Yükleme başarısız oldu"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Yükleme başarısız oldu (HTTP %s)"
 

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -281,7 +281,7 @@ msgstr "Користувацький"
 msgid "Name"
 msgstr "Назва"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "Розмір"
 
@@ -305,7 +305,7 @@ msgstr "Замінить наявний файл «%s»."
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "Перетягніть шрифт .woff2 сюди або натисніть, щоб вибрати"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "Підтвердити завантаження"
 
@@ -313,11 +313,11 @@ msgstr "Підтвердити завантаження"
 msgid "Custom Fonts"
 msgstr "Користувацькі шрифти"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Непідтримуваний тип файлу. Дозволені: %s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "Розмір файлу %s, що перевищує ліміт 8 МБ."
 
@@ -359,9 +359,7 @@ msgstr ""
 "Основний колір переднього плану для заголовків, основного тексту, іконок та "
 "значень форм."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "Видалити"
 
@@ -1174,12 +1172,11 @@ msgstr ""
 "фону сторінки входу. Файли зберігаються в <code>/www/luci-static/aurora/"
 "images/</code>."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "Помилка завантаження"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "Помилка завантаження (HTTP %s)"
 

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -42,10 +42,6 @@ msgstr "Акцент для попереджень, зауважень та по
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "Акценти для сповіщень, валідації та зворотного зв'язку про статус."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "Дії"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr ""
@@ -108,10 +104,6 @@ msgid ""
 msgstr ""
 "Ви впевнені, що хочете оновити <strong>%h</strong> до версії <strong>%h</"
 "strong>?"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "Ім'я файлу ресурсу"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -289,6 +281,26 @@ msgstr "Користувацький"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Користувацькі шрифти"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "Назва"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "Розмір"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "Тип"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "Ім'я файлу (з розширенням)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "Назвіть файл login-bg.*, щоб використовувати його як тло сторінки входу."
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -467,10 +479,6 @@ msgstr "Не вдалося видалити: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "Легке наведення"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "Назва шрифту"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -825,10 +833,6 @@ msgstr "Пресет"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "Пресет успішно застосовано."
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "Перегляд"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -294,6 +294,10 @@ msgstr "Користувацький"
 msgid "Custom Fonts"
 msgstr "Користувацькі шрифти"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "Користувацькі шрифти зберігаються в обмеженій флеш-пам'яті маршрутизатора та завантажуються кожним браузером під час першого відкриття. Для шрифтів CJK краще використовувати .woff2 із підмножиною, що містить лише потрібні гліфи, щоб заощадити місце та пришвидшити завантаження."
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Небезпека"
@@ -755,8 +759,8 @@ msgid "On-Brand Text"
 msgstr "Текст на фоні бренду"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "Приймаються лише файли .woff2 розміром до 4 МБ."
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "Приймаються лише файли .woff2 розміром до 8 МБ."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -319,8 +319,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "Видалити «%s»? Інтерфейс повернеться до типового шрифту."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "Користувацькі шрифти зберігаються в обмеженій флеш-пам'яті маршрутизатора та завантажуються кожним браузером під час першого відкриття. Для шрифтів CJK краще використовувати .woff2 із підмножиною, що містить лише потрібні гліфи, щоб заощадити місце та пришвидшити завантаження."
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "Файли користувацьких шрифтів мають бути якомога меншими, оскільки вони зберігаються в обмеженій флеш-пам'яті маршрутизатора."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -281,6 +281,7 @@ msgstr "Користувацький"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Користувацькі шрифти"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Назва"
@@ -301,6 +302,9 @@ msgstr "Ім'я файлу (з розширенням)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "Назвіть файл login-bg.*, щоб використовувати його як тло сторінки входу."
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "Замінить наявний файл «%s»."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -277,11 +277,6 @@ msgstr "Радіус скруглення кутів"
 msgid "Custom"
 msgstr "Користувацький"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "Користувацькі шрифти"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "Назва"
@@ -337,6 +332,10 @@ msgstr "Видалити «%s»? Інтерфейс повернеться до 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Файли користувацьких шрифтів мають бути якомога меншими, оскільки вони зберігаються в обмеженій флеш-пам'яті маршрутизатора."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "Бібліотека шрифтів"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -310,6 +310,10 @@ msgid "Confirm Upload"
 msgstr "Підтвердити завантаження"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "Користувацькі шрифти"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "Прибрати файл"
 

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -333,10 +333,6 @@ msgstr "Видалити «%s»? Інтерфейс повернеться до 
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "Файли користувацьких шрифтів мають бути якомога меншими, оскільки вони зберігаються в обмеженій флеш-пам'яті маршрутизатора."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "Бібліотека шрифтів"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "Небезпека"

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -488,10 +488,6 @@ msgstr ""
 "Поля приймають формати #hex, rgb(), hsl(), lab() та oklch(). Палітра "
 "заповнює hex; інші формати можна ввести вручну."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "Файл"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr ""
@@ -1172,10 +1168,6 @@ msgstr "Помилка оновлення: %s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "Оновлення пакета"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "Завантажити"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -237,10 +237,6 @@ msgstr "Перевірка наявності оновлень..."
 msgid "Checking..."
 msgstr "Перевірка..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "Виберіть файл .woff2 і вкажіть назву шрифту"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "Виберіть точний колір для цього токена"
@@ -293,6 +289,34 @@ msgstr "Користувацький"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "Користувацькі шрифти"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "Перетягніть шрифт .woff2 сюди або натисніть, щоб вибрати"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "Підтвердити завантаження"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "Прибрати файл"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "Непідтримуваний тип файлу. Дозволені: %s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "Розмір файлу %s, що перевищує ліміт 8 МБ."
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "Видалити користувацький шрифт"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "Видалити «%s»? Інтерфейс повернеться до типового шрифту."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -627,8 +651,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "Некоректний, відсутній або циклічний вираз кольору."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1152,11 +1176,6 @@ msgstr "Оновлення пакета"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "Завантажити"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "Завантажити користувацький шрифт"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -924,15 +924,8 @@ msgid "Sans-Serif Typeface"
 msgstr "Шрифт без засічок"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"Шрифти без засічок і моноширинні, що використовуються в усій темі. Веб-"
-"шрифти завантажуються один раз із джерел із зафіксованою версією та "
-"перевіркою контрольної суми й роздаються локально; сторінки ніколи не "
-"завантажують шрифти з інтернету."
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "Шрифти без засічок і моноширинні, що використовуються в усій темі. Виберіть дібраний веб-шрифт — він завантажується один раз після збереження з джерел із зафіксованою версією та перевіркою контрольної суми, а потім роздається локально — або завантажте власні файли .woff2."
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/uk/aurora-config.po
+++ b/po/uk/aurora-config.po
@@ -314,10 +314,6 @@ msgid "Custom Fonts"
 msgstr "Користувацькі шрифти"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "Прибрати файл"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "Непідтримуваний тип файлу. Дозволені: %s"
 

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -268,7 +268,7 @@ msgstr "自定义"
 msgid "Name"
 msgstr "名称"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "大小"
 
@@ -292,7 +292,7 @@ msgstr "将替换已存在的“%s”。"
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "将 .woff2 字体拖到这里,或点击选择文件"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "确认上传"
 
@@ -300,11 +300,11 @@ msgstr "确认上传"
 msgid "Custom Fonts"
 msgstr "自定义字体"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "不支持的文件类型,仅支持:%s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "文件大小为 %s,超出 8MB 限制。"
 
@@ -344,9 +344,7 @@ msgstr "默认"
 msgid "Default foreground for headings, body text, icons, and form values."
 msgstr "用于标题、正文、图标和表单值的默认前景色。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "删除"
 
@@ -1123,12 +1121,11 @@ msgstr ""
 "上传并管理图标、网站图标、PWA 资源和登录背景的图片。文件将保存在 <code>/www/"
 "luci-static/aurora/images/</code> 中。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "上传失败"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "上传失败 (HTTP %s)"
 

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -306,8 +306,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "确定删除“%s”?界面将回退到默认字体。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "自定义字体会存放在路由器有限的闪存中,并在每个浏览器首次加载时下载。中日韩字体建议使用仅包含所需字形的子集化 .woff2,以节省空间并加快加载。"
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "自定义字体文件应尽可能小,因为它们存放在路由器有限的闪存中。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -281,6 +281,10 @@ msgstr "自定义"
 msgid "Custom Fonts"
 msgstr "自定义字体"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "自定义字体会存放在路由器有限的闪存中,并在每个浏览器首次加载时下载。中日韩字体建议使用仅包含所需字形的子集化 .woff2,以节省空间并加快加载。"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "危险"
@@ -713,8 +717,8 @@ msgid "On-Brand Text"
 msgstr "品牌背景上的文本"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "仅支持不超过 4MB 的 .woff2 文件。"
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "仅支持不超过 8MB 的 .woff2 文件。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -297,6 +297,10 @@ msgid "Confirm Upload"
 msgstr "确认上传"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "自定义字体"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "移除文件"
 

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -224,10 +224,6 @@ msgstr "正在检查更新..."
 msgid "Checking..."
 msgstr "正在检查..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "请选择 .woff2 文件并填写字体名称"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "为此令牌（Token）选择具体的颜色"
@@ -280,6 +276,34 @@ msgstr "自定义"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "自定义字体"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "将 .woff2 字体拖到这里,或点击选择文件"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "确认上传"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "移除文件"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "不支持的文件类型,仅支持:%s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "文件大小为 %s,超出 8MB 限制。"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "删除自定义字体"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "确定删除“%s”?界面将回退到默认字体。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -590,8 +614,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "颜色表达式无效、缺失或存在循环引用。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1100,11 +1124,6 @@ msgstr "正在更新软件包"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "上传"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "上传自定义字体"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -320,10 +320,6 @@ msgstr "确定删除“%s”?界面将回退到默认字体。"
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "自定义字体文件应尽可能小,因为它们存放在路由器有限的闪存中。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "字体库"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "危险"

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -301,10 +301,6 @@ msgid "Custom Fonts"
 msgstr "自定义字体"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "移除文件"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "不支持的文件类型,仅支持:%s"
 

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -41,10 +41,6 @@ msgstr "用于警告、通知和校验信息的强调色。"
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "用于通知、校验和状态反馈的强调色。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "操作"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr "添加快捷方式、指定图标，并拖动行进行排序。"
@@ -102,10 +98,6 @@ msgid ""
 "Are you sure you want to update <strong>%h</strong> to version <strong>%h</"
 "strong>?"
 msgstr "确定要将 <strong>%h</strong> 更新到版本 <strong>%h</strong> 吗？"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "资源文件名"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -276,6 +268,26 @@ msgstr "自定义"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "自定义字体"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "名称"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "大小"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "类型"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "文件名(含扩展名)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "命名为 login-bg.* 可用作登录页背景。"
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -446,10 +458,6 @@ msgstr "删除失败：%s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "微淡悬停态"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "字体名称"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -783,10 +791,6 @@ msgstr "预设"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "预设应用成功。"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "预览"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -879,13 +879,8 @@ msgid "Sans-Serif Typeface"
 msgstr "无衬线字体"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"主题全局使用的无衬线与等宽字体。网络字体仅从固定版本、经校验和验证的来源下载"
-"一次并由本机提供；页面不会从互联网加载字体。"
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "主题全局使用的无衬线与等宽字体。可选用精选网络字体——保存后才从固定版本、经校验和验证的来源下载一次,此后由本机提供——也可上传自己的 .woff2 字体文件。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -467,10 +467,6 @@ msgstr ""
 "字段支持输入 #hex、rgb()、hsl()、lab() 以及 oklch()。拾色器将填充十六进制格"
 "式，其他格式可手动输入。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "文件"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr "表单控件的填充色:输入框、下拉框、文本域和复选框。"
@@ -1120,10 +1116,6 @@ msgstr "更新失败：%s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "正在更新软件包"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "上传"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -876,7 +876,7 @@ msgstr "无衬线字体"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
 msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
-msgstr "主题全局使用的无衬线与等宽字体。可选用精选网络字体——保存后才从固定版本、经校验和验证的来源下载一次,此后由本机提供——也可上传自己的 .woff2 字体文件。"
+msgstr "主题全局使用的无衬线与等宽字体。可选用精选网络字体——保存后才从固定版本、经校验的来源下载一次,此后由本机提供——也可上传自己的 .woff2 字体文件。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -264,11 +264,6 @@ msgstr "圆角半径"
 msgid "Custom"
 msgstr "自定义"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "自定义字体"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "名称"
@@ -324,6 +319,10 @@ msgstr "确定删除“%s”?界面将回退到默认字体。"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "自定义字体文件应尽可能小,因为它们存放在路由器有限的闪存中。"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "字体库"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/zh_Hans/aurora-config.po
+++ b/po/zh_Hans/aurora-config.po
@@ -268,6 +268,7 @@ msgstr "自定义"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "自定义字体"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "名称"
@@ -288,6 +289,9 @@ msgstr "文件名(含扩展名)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "命名为 login-bg.* 可用作登录页背景。"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "将替换已存在的“%s”。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -306,8 +306,8 @@ msgid "Delete '%s'? The interface will fall back to the default typeface."
 msgstr "確定刪除「%s」?介面將回退為預設字型。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
-msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
-msgstr "自訂字型會儲存在路由器有限的快閃記憶體中,並在每個瀏覽器首次載入時下載。中日韓字型建議使用僅包含所需字形的子集化 .woff2,以節省空間並加快載入。"
+msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
+msgstr "自訂字型檔案應盡可能小,因為它們儲存在路由器有限的快閃記憶體中。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -224,10 +224,6 @@ msgstr "正在檢查更新..."
 msgid "Checking..."
 msgstr "正在檢查..."
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2213
-msgid "Choose a .woff2 file and a family name"
-msgstr "請選擇 .woff2 檔案並填寫字型名稱"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:967
 msgid "Choose a literal color for this token"
 msgstr "為此變數選擇一個實際色彩"
@@ -280,6 +276,34 @@ msgstr "自訂"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "自訂字型"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Drop a .woff2 font here, or click to browse"
+msgstr "將 .woff2 字型拖曳到這裡,或點擊選擇檔案"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Confirm Upload"
+msgstr "確認上傳"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Remove file"
+msgstr "移除檔案"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Unsupported file type. Allowed: %s"
+msgstr "不支援的檔案類型,僅支援:%s"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "File is %s, exceeding the 8MB limit."
+msgstr "檔案大小為 %s,超出 8MB 限制。"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete Custom Font"
+msgstr "刪除自訂字型"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Delete '%s'? The interface will fall back to the default typeface."
+msgstr "確定刪除「%s」?介面將回退為預設字型。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
@@ -590,8 +614,8 @@ msgid "Invalid, missing, or cyclic color expression."
 msgstr "顏色運算式無效、缺失或存在循環參照。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2533
-msgid "JPG · PNG · WebP · AVIF · SVG · GIF"
-msgstr "JPG · PNG · WebP · AVIF · SVG · GIF"
+msgid "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
+msgstr "JPG · PNG · WebP · AVIF · SVG · GIF · ICO"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:396
 msgid "Latest Version"
@@ -1100,11 +1124,6 @@ msgstr "正在更新套件"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
 msgid "Upload"
 msgstr "上傳"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2182
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2278
-msgid "Upload Custom Font"
-msgstr "上傳自訂字型"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -281,6 +281,10 @@ msgstr "自訂"
 msgid "Custom Fonts"
 msgstr "自訂字型"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
+msgid "Custom fonts are stored in the router's limited flash storage and downloaded by every browser on first load. For CJK typefaces, prefer a subsetted .woff2 with only the glyphs you need to save space and load faster."
+msgstr "自訂字型會儲存在路由器有限的快閃記憶體中,並在每個瀏覽器首次載入時下載。中日韓字型建議使用僅包含所需字形的子集化 .woff2,以節省空間並加快載入。"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "危險"
@@ -713,8 +717,8 @@ msgid "On-Brand Text"
 msgstr "品牌背景上的文字"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2183
-msgid "Only .woff2 files up to 4MB are accepted."
-msgstr "僅支援不超過 4MB 的 .woff2 檔案。"
+msgid "Only .woff2 files up to 8MB are accepted."
+msgstr "僅支援不超過 8MB 的 .woff2 檔案。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:308
 msgid "Opaque surface for the expanded mega menu and its header."

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -879,13 +879,8 @@ msgid "Sans-Serif Typeface"
 msgstr "無襯線字型"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2084
-msgid ""
-"Sans-serif and monospace typefaces used across the theme. Webfonts are "
-"downloaded once from pinned, checksum-verified sources and served locally; "
-"pages never load fonts from the internet."
-msgstr ""
-"主題全域使用的無襯線與等寬字型。網路字型僅從固定版本、經檢查碼驗證的來源下載"
-"一次並由本機提供；頁面不會從網際網路載入字型。"
+msgid "Sans-serif and monospace typefaces used across the theme. Pick a curated webfont — downloaded once after saving, from pinned, checksum-verified sources, then served locally — or upload your own .woff2 files."
+msgstr "主題全域使用的無襯線與等寬字型。可選用精選網路字型——儲存後才從固定版本、經檢查碼驗證的來源下載一次,之後由本機提供——也可上傳自己的 .woff2 字型檔案。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:960
 msgid "Saved or preset value"

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -268,6 +268,7 @@ msgstr "自訂"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "自訂字型"
+
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "名稱"
@@ -288,6 +289,9 @@ msgstr "檔案名稱(含副檔名)"
 msgid "Name it login-bg.* to use it as the login page background."
 msgstr "命名為 login-bg.* 可用作登入頁背景。"
 
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Will replace the existing '%s'."
+msgstr "將取代既有的「%s」。"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -301,10 +301,6 @@ msgid "Custom Fonts"
 msgstr "自訂字型"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Remove file"
-msgstr "移除檔案"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "不支援的檔案類型,僅支援:%s"
 

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -320,10 +320,6 @@ msgstr "確定刪除「%s」?介面將回退為預設字型。"
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "自訂字型檔案應盡可能小,因為它們儲存在路由器有限的快閃記憶體中。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
-msgid "Font Library"
-msgstr "字型庫"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"
 msgstr "危險"

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -268,7 +268,7 @@ msgstr "自訂"
 msgid "Name"
 msgstr "名稱"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Size"
 msgstr "大小"
 
@@ -292,7 +292,7 @@ msgstr "將取代既有的「%s」。"
 msgid "Drop a .woff2 font here, or click to browse"
 msgstr "將 .woff2 字型拖曳到這裡,或點擊選擇檔案"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Confirm Upload"
 msgstr "確認上傳"
 
@@ -300,11 +300,11 @@ msgstr "確認上傳"
 msgid "Custom Fonts"
 msgstr "自訂字型"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Unsupported file type. Allowed: %s"
 msgstr "不支援的檔案類型,僅支援:%s"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "File is %s, exceeding the 8MB limit."
 msgstr "檔案大小為 %s,超出 8MB 限制。"
 
@@ -344,9 +344,7 @@ msgstr "預設"
 msgid "Default foreground for headings, body text, icons, and form values."
 msgstr "用於標題、正文、圖示和表單值的預設前景。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2258
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2692
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2698
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Delete"
 msgstr "刪除"
 
@@ -1123,12 +1121,11 @@ msgstr ""
 "上傳並管理圖示、網站圖示、PWA 素材和登入背景的圖片。檔案將儲存在 <code>/www/"
 "luci-static/aurora/images/</code> 中。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2158
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2588
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed"
 msgstr "上傳失敗"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2560
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/utils/asset-upload.js:1
 msgid "Upload failed (HTTP %s)"
 msgstr "上傳失敗 (HTTP %s)"
 

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -297,6 +297,10 @@ msgid "Confirm Upload"
 msgstr "確認上傳"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Custom Fonts"
+msgstr "自訂字型"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Remove file"
 msgstr "移除檔案"
 

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -264,11 +264,6 @@ msgstr "圓角半徑"
 msgid "Custom"
 msgstr "自訂"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2137
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
-msgid "Custom Fonts"
-msgstr "自訂字型"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Name"
 msgstr "名稱"
@@ -324,6 +319,10 @@ msgstr "確定刪除「%s」?介面將回退為預設字型。"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2196
 msgid "Keep custom font files as small as possible, as they are stored in the router's limited flash storage."
 msgstr "自訂字型檔案應盡可能小,因為它們儲存在路由器有限的快閃記憶體中。"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Font Library"
+msgstr "字型庫"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:180
 msgid "Danger"

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -41,10 +41,6 @@ msgstr "用於警告、通知和驗證訊息的強調色。"
 msgid "Accents for notifications, validation, and status feedback."
 msgstr "用於通知、驗證和狀態回饋的強調色。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2717
-msgid "Actions"
-msgstr "動作"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2897
 msgid "Add shortcuts, assign icons, and drag rows to reorder them."
 msgstr "新增捷徑、指定圖示，並拖曳各列以重新排序。"
@@ -102,10 +98,6 @@ msgid ""
 "Are you sure you want to update <strong>%h</strong> to version <strong>%h</"
 "strong>?"
 msgstr "確定要將 <strong>%h</strong> 更新至版本 <strong>%h</strong> 嗎？"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2716
-msgid "Asset Filename"
-msgstr "素材檔案名稱"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2740
 msgid ""
@@ -276,6 +268,26 @@ msgstr "自訂"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2264
 msgid "Custom Fonts"
 msgstr "自訂字型"
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name"
+msgstr "名稱"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Size"
+msgstr "大小"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Type"
+msgstr "類型"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Filename (with extension)"
+msgstr "檔案名稱(含副檔名)"
+
+#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
+msgid "Name it login-bg.* to use it as the login page background."
+msgstr "命名為 login-bg.* 可用作登入頁背景。"
+
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1
 msgid "Drop a .woff2 font here, or click to browse"
@@ -446,10 +458,6 @@ msgstr "刪除失敗：%s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:228
 msgid "Faint Hover"
 msgstr "微淡懸停態"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2189
-msgid "Family"
-msgstr "字型名稱"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2765
 msgid "Favicon (ICO / Legacy)"
@@ -783,10 +791,6 @@ msgstr "預設組"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:1665
 msgid "Preset applied successfully."
 msgstr "預設組套用成功。"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2715
-msgid "Preview"
-msgstr "預覽"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2113
 msgid ""

--- a/po/zh_Hant/aurora-config.po
+++ b/po/zh_Hant/aurora-config.po
@@ -467,10 +467,6 @@ msgstr ""
 "欄位支援輸入 #hex、rgb()、hsl()、lab() 以及 oklch()。挑色器將填入十六進位格"
 "式，其他格式可手動輸入。"
 
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2193
-msgid "File"
-msgstr "檔案"
-
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:218
 msgid "Fill for form controls: inputs, selects, textareas, and checkboxes."
 msgstr "表單控制項的填充色:輸入框、下拉選單、文字區域與核取方塊。"
@@ -1120,10 +1116,6 @@ msgstr "更新失敗：%s"
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/version.js:66
 msgid "Updating Package"
 msgstr "正在更新套件"
-
-#: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2229
-msgid "Upload"
-msgstr "上傳"
 
 #: applications/luci-app-aurora-config/htdocs/luci-static/resources/view/aurora/theme.js:2429
 msgid ""

--- a/root/usr/libexec/rpcd/luci.aurora
+++ b/root/usr/libexec/rpcd/luci.aurora
@@ -64,6 +64,9 @@ receive_upload() {
 			echo '{ "result": 1, "error": "Unsupported image type" }'; return 1 ;;
 		esac
 		;;
+	*)
+		rm -f "$ru_tmp"
+		echo '{ "result": 1, "error": "Unknown upload kind" }'; return 1 ;;
 	esac
 	return 0
 }

--- a/root/usr/libexec/rpcd/luci.aurora
+++ b/root/usr/libexec/rpcd/luci.aurora
@@ -862,6 +862,9 @@ json_add_font_presets() {
 			json_add_string "name" "$cname"
 			json_add_string "family" "$cfamily"
 			json_add_string "stack" "$cstack"
+			csize=0
+			[ -f "$FONT_CUSTOM_PATH/${base}.woff2" ] && csize=$(wc -c < "$FONT_CUSTOM_PATH/${base}.woff2")
+			json_add_int "size" "$csize"
 		json_close_object
 	done
 	json_close_array
@@ -878,6 +881,13 @@ json_add_icons() {
 		done
 	fi
 	json_close_array
+	json_add_object "icon_sizes"
+	if [ -d "$ICON_PATH" ]; then
+		for file in "$ICON_PATH"/*; do
+			[ -f "$file" ] && json_add_int "${file##*/}" "$(wc -c < "$file")"
+		done
+	fi
+	json_close_object
 }
 
 json_add_theme_preset_snapshot() {

--- a/root/usr/libexec/rpcd/luci.aurora
+++ b/root/usr/libexec/rpcd/luci.aurora
@@ -8,7 +8,7 @@ readonly FONT_CSS_FILE="$FONT_PATH/aurora-font.css"
 readonly FONT_JOB_PATH="/tmp/aurora_font_jobs"
 readonly FONT_TMP_UPLOAD="/tmp/aurora_font.tmp"
 readonly FONT_CUSTOM_PATH="$FONT_PATH/custom"
-readonly FONT_MAX_UPLOAD=8388608
+readonly MAX_UPLOAD=8388608
 readonly TMP_UPLOAD_PATH="/tmp/aurora_icon.tmp"
 readonly DOWNLOAD_PATH="/tmp/aurora_downloads"
 readonly CONFIG_FILE="/etc/config/aurora"
@@ -31,6 +31,42 @@ readonly COLOR_TOKEN_KEYS="$(grep -v '^#' "$COLOR_TOKENS_FILE" 2>/dev/null)"
 # Number of color options a valid preset template must contain (every token in
 # both light_ and dark_ variants). Derived once from COLOR_TOKEN_KEYS.
 PRESET_EXPECTED_COUNT=$(( $(printf '%s\n' $COLOR_TOKEN_KEYS | grep -c .) * 2 ))
+
+# Shared gate for uploaded tmp files: size cap, per-kind content checks,
+# and tmp cleanup on every rejection. Callers get return 0 only when the
+# tmp file is safe to move into place; on failure the JSON error has
+# already been emitted, so call sites just `|| exit 0`.
+receive_upload() {
+	ru_tmp="$1"; ru_kind="$2"; ru_name="$3"
+	[ -f "$ru_tmp" ] || {
+		echo '{ "result": 1, "error": "No uploaded file" }'; return 1; }
+	ru_size=$(wc -c < "$ru_tmp")
+	[ "$ru_size" -le "$MAX_UPLOAD" ] || {
+		rm -f "$ru_tmp"
+		echo '{ "result": 1, "error": "File exceeds 8MB limit" }'; return 1; }
+	case "$ru_kind" in
+	font)
+		[ "$(head -c 4 "$ru_tmp")" = "wOF2" ] || {
+			rm -f "$ru_tmp"
+			echo '{ "result": 1, "error": "Not a woff2 file" }'; return 1; }
+		;;
+	image)
+		case "$ru_name" in
+		""|*/*|*..*)
+			rm -f "$ru_tmp"
+			echo '{ "result": 255 }'; return 1 ;;
+		esac
+		ru_ext=$(printf '%s' "$ru_name" | sed 's/.*\.//' | tr 'A-Z' 'a-z')
+		case "$ru_ext" in
+		jpg|jpeg|png|webp|avif|svg|gif|ico) ;;
+		*)
+			rm -f "$ru_tmp"
+			echo '{ "result": 1, "error": "Unsupported image type" }'; return 1 ;;
+		esac
+		;;
+	esac
+	return 0
+}
 
 # Fail fast when the shipped key list is missing or empty: with zero keys the
 # expected-count check degrades to 0==0, so preset/import validation would
@@ -1045,15 +1081,7 @@ case "$1" in
 		[ ${#family} -le 64 ] || {
 			rm -f "$FONT_TMP_UPLOAD"
 			echo '{ "result": 1, "error": "Family name too long" }'; exit 0; }
-		[ -f "$FONT_TMP_UPLOAD" ] || {
-			echo '{ "result": 1, "error": "No uploaded file" }'; exit 0; }
-		size=$(wc -c < "$FONT_TMP_UPLOAD")
-		[ "$size" -le "$FONT_MAX_UPLOAD" ] || {
-			rm -f "$FONT_TMP_UPLOAD"
-			echo '{ "result": 1, "error": "File exceeds 8MB limit" }'; exit 0; }
-		[ "$(head -c 4 "$FONT_TMP_UPLOAD")" = "wOF2" ] || {
-			rm -f "$FONT_TMP_UPLOAD"
-			echo '{ "result": 1, "error": "Not a woff2 file" }'; exit 0; }
+		receive_upload "$FONT_TMP_UPLOAD" font || exit 0
 
 		slug=$(printf '%s' "$family" | tr 'A-Z' 'a-z' | sed 's/[^a-z0-9]\{1,\}/-/g;s/^-//;s/-$//')
 		[ -n "$slug" ] || {
@@ -1232,15 +1260,16 @@ FACE
 
 	"upload_icon")
 		read -r input; json_load "$input"; json_get_var filename "filename"; json_cleanup
-		if dirname "$filename" | grep -q "\.\."; then echo '{ "result": 255 }'; exit 255; fi
-		
+		receive_upload "$TMP_UPLOAD_PATH" image "$filename" || exit 0
+
 		mkdir -p "$ICON_PATH"
 		if mv "$TMP_UPLOAD_PATH" "$ICON_PATH/$filename" 2>"/dev/null"; then
 			chmod 0644 "$ICON_PATH/$filename"
 			update_icon_cache_timestamp
 			echo '{ "result": 0 }'
 		else
-			echo '{ "result": 1 }'
+			rm -f "$TMP_UPLOAD_PATH"
+			echo '{ "result": 1, "error": "Failed to store file" }'
 		fi
 		;;
 

--- a/root/usr/libexec/rpcd/luci.aurora
+++ b/root/usr/libexec/rpcd/luci.aurora
@@ -1120,7 +1120,10 @@ case "$1" in
 		stack="\"$family\", $default_stack"
 
 		mkdir -p "$FONT_CUSTOM_PATH"
-		mv "$FONT_TMP_UPLOAD" "$FONT_CUSTOM_PATH/${slot}-${slug}.woff2"
+		if ! mv "$FONT_TMP_UPLOAD" "$FONT_CUSTOM_PATH/${slot}-${slug}.woff2" 2>"/dev/null"; then
+			rm -f "$FONT_TMP_UPLOAD"
+			echo '{ "result": 1, "error": "Failed to store file" }'; exit 0
+		fi
 		chmod 644 "$FONT_CUSTOM_PATH/${slot}-${slug}.woff2"
 		printf '%s|%s\n' "$family" "$stack" > "$FONT_CUSTOM_PATH/${slot}-${slug}.meta"
 		chmod 644 "$FONT_CUSTOM_PATH/${slot}-${slug}.meta"

--- a/root/usr/libexec/rpcd/luci.aurora
+++ b/root/usr/libexec/rpcd/luci.aurora
@@ -8,7 +8,7 @@ readonly FONT_CSS_FILE="$FONT_PATH/aurora-font.css"
 readonly FONT_JOB_PATH="/tmp/aurora_font_jobs"
 readonly FONT_TMP_UPLOAD="/tmp/aurora_font.tmp"
 readonly FONT_CUSTOM_PATH="$FONT_PATH/custom"
-readonly FONT_MAX_UPLOAD=4194304
+readonly FONT_MAX_UPLOAD=8388608
 readonly TMP_UPLOAD_PATH="/tmp/aurora_icon.tmp"
 readonly DOWNLOAD_PATH="/tmp/aurora_downloads"
 readonly CONFIG_FILE="/etc/config/aurora"
@@ -1050,7 +1050,7 @@ case "$1" in
 		size=$(wc -c < "$FONT_TMP_UPLOAD")
 		[ "$size" -le "$FONT_MAX_UPLOAD" ] || {
 			rm -f "$FONT_TMP_UPLOAD"
-			echo '{ "result": 1, "error": "File exceeds 4MB limit" }'; exit 0; }
+			echo '{ "result": 1, "error": "File exceeds 8MB limit" }'; exit 0; }
 		[ "$(head -c 4 "$FONT_TMP_UPLOAD")" = "wOF2" ] || {
 			rm -f "$FONT_TMP_UPLOAD"
 			echo '{ "result": 1, "error": "Not a woff2 file" }'; exit 0; }

--- a/tests/asset-upload-module.test.mjs
+++ b/tests/asset-upload-module.test.mjs
@@ -17,6 +17,7 @@ test("asset-upload module exposes the shared surface", async () => {
     "uploadToRouter",
     "createDropzone",
     "createProgressRow",
+    "createAssetManager",
     "confirmDelete",
   ])
     assert.ok(src.includes(name), `missing export: ${name}`);

--- a/tests/asset-upload-module.test.mjs
+++ b/tests/asset-upload-module.test.mjs
@@ -13,14 +13,16 @@ test("asset-upload module exposes the shared surface", async () => {
   for (const name of [
     "MAX_UPLOAD",
     "formatSize",
+    "extOf",
     "checkFile",
     "uploadToRouter",
-    "createDropzone",
-    "createProgressRow",
     "createAssetManager",
     "confirmDelete",
   ])
     assert.ok(src.includes(name), `missing export: ${name}`);
+
+  assert.ok(!src.includes("createDropzone"), "dead export must stay deleted");
+  assert.ok(!src.includes("createProgressRow"), "dead export must stay deleted");
 });
 
 test("module owns the only cgi-upload pipeline", async () => {

--- a/tests/asset-upload-module.test.mjs
+++ b/tests/asset-upload-module.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const SRC = "htdocs/luci-static/resources/utils/asset-upload.js";
+
+test("asset-upload module exposes the shared surface", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.match(src, /^"require baseclass";/m);
+  assert.match(src, /^"require rpc";/m);
+  assert.match(src, /^"require ui";/m);
+  assert.match(src, /return baseclass\.extend\(/);
+  for (const name of [
+    "MAX_UPLOAD",
+    "formatSize",
+    "checkFile",
+    "uploadToRouter",
+    "createDropzone",
+    "createProgressRow",
+    "confirmDelete",
+  ])
+    assert.ok(src.includes(name), `missing export: ${name}`);
+});
+
+test("module owns the only cgi-upload pipeline", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.match(src, /\/cgi-bin\/cgi-upload/);
+  assert.match(src, /filemode.*0600/);
+});

--- a/tests/rpcd-upload-validation.test.mjs
+++ b/tests/rpcd-upload-validation.test.mjs
@@ -30,3 +30,11 @@ test("list endpoints expose byte sizes", async () => {
   assert.match(src, /json_add_int "size" "\$csize"/);
   assert.match(src, /json_add_object "icon_sizes"/);
 });
+
+test("both upload mv sites are guarded and clean tmp on failure", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.match(src, /if ! mv "\$FONT_TMP_UPLOAD"/);
+  assert.match(src, /if mv "\$TMP_UPLOAD_PATH"/);
+  const storeErrors = src.match(/Failed to store file/g) || [];
+  assert.equal(storeErrors.length, 2, "font and icon mv failure paths");
+});

--- a/tests/rpcd-upload-validation.test.mjs
+++ b/tests/rpcd-upload-validation.test.mjs
@@ -24,3 +24,9 @@ test("image allowlist covers favicon .ico and every advertised format", async ()
   const src = await readFile(SRC, "utf8");
   assert.match(src, /jpg\|jpeg\|png\|webp\|avif\|svg\|gif\|ico/);
 });
+
+test("list endpoints expose byte sizes", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.match(src, /json_add_int "size" "\$csize"/);
+  assert.match(src, /json_add_object "icon_sizes"/);
+});

--- a/tests/rpcd-upload-validation.test.mjs
+++ b/tests/rpcd-upload-validation.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const SRC = "root/usr/libexec/rpcd/luci.aurora";
+
+test("rpcd defines shared MAX_UPLOAD and receive_upload()", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.match(src, /readonly MAX_UPLOAD=8388608/);
+  assert.ok(!src.includes("FONT_MAX_UPLOAD"), "FONT_MAX_UPLOAD must be renamed");
+  assert.match(src, /^receive_upload\(\)/m);
+});
+
+test("upload_font and upload_icon route through receive_upload", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.match(src, /receive_upload "\$FONT_TMP_UPLOAD" font \|\| exit 0/);
+  assert.match(
+    src,
+    /receive_upload "\$TMP_UPLOAD_PATH" image "\$filename" \|\| exit 0/,
+  );
+});
+
+test("image allowlist covers favicon .ico and every advertised format", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.match(src, /jpg\|jpeg\|png\|webp\|avif\|svg\|gif\|ico/);
+});

--- a/tests/theme-upload-integration.test.mjs
+++ b/tests/theme-upload-integration.test.mjs
@@ -39,6 +39,10 @@ test("theme.js owns zero raw upload plumbing after icon adoption", async () => {
   assert.ok(!src.includes("new XMLHttpRequest"), "XHR must live in the module");
   assert.ok(!src.includes("cgi-bin/cgi-upload"), "upload URL must live in the module");
   assert.match(src, /GIF · ICO/);
-  assert.match(src, /exts: \["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"\]/);
+  assert.match(
+    src,
+    /const ICON_EXTS = \["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"\];/,
+  );
+  assert.match(src, /exts: ICON_EXTS/);
   assert.match(src, /Failed to delete: %s/); // msgid regressed once; lock it
 });

--- a/tests/theme-upload-integration.test.mjs
+++ b/tests/theme-upload-integration.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const SRC = "htdocs/luci-static/resources/view/aurora/theme.js";
+
+test("theme.js requires the shared asset-upload module", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.match(src, /^"require utils\.asset-upload as assetUpload";/m);
+});
+
+test("font upload modal is gone, replaced by dropzone flow", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.ok(!src.includes("openUploadModal"), "modal flow must be removed");
+  assert.ok(
+    !src.includes("Upload Custom Font"),
+    "modal title/button string must be removed",
+  );
+  assert.match(src, /assetUpload\.createDropzone\(/);
+  assert.match(src, /assetUpload\.confirmDelete\(/);
+});

--- a/tests/theme-upload-integration.test.mjs
+++ b/tests/theme-upload-integration.test.mjs
@@ -19,3 +19,11 @@ test("font upload modal is gone, replaced by dropzone flow", async () => {
   assert.match(src, /assetUpload\.createDropzone\(/);
   assert.match(src, /assetUpload\.confirmDelete\(/);
 });
+
+test("theme.js owns zero raw upload plumbing after icon adoption", async () => {
+  const src = await readFile(SRC, "utf8");
+  assert.ok(!src.includes("new XMLHttpRequest"), "XHR must live in the module");
+  assert.ok(!src.includes("cgi-bin/cgi-upload"), "upload URL must live in the module");
+  assert.match(src, /GIF · ICO/);
+  assert.match(src, /exts: \["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"\]/);
+});

--- a/tests/theme-upload-integration.test.mjs
+++ b/tests/theme-upload-integration.test.mjs
@@ -26,4 +26,5 @@ test("theme.js owns zero raw upload plumbing after icon adoption", async () => {
   assert.ok(!src.includes("cgi-bin/cgi-upload"), "upload URL must live in the module");
   assert.match(src, /GIF · ICO/);
   assert.match(src, /exts: \["jpg", "jpeg", "png", "webp", "avif", "svg", "gif", "ico"\]/);
+  assert.match(src, /Failed to delete: %s/); // msgid regressed once; lock it
 });

--- a/tests/theme-upload-integration.test.mjs
+++ b/tests/theme-upload-integration.test.mjs
@@ -9,15 +9,29 @@ test("theme.js requires the shared asset-upload module", async () => {
   assert.match(src, /^"require utils\.asset-upload as assetUpload";/m);
 });
 
-test("font upload modal is gone, replaced by dropzone flow", async () => {
+test("font upload modal is gone, replaced by the shared asset manager", async () => {
   const src = await readFile(SRC, "utf8");
   assert.ok(!src.includes("openUploadModal"), "modal flow must be removed");
   assert.ok(
     !src.includes("Upload Custom Font"),
     "modal title/button string must be removed",
   );
-  assert.match(src, /assetUpload\.createDropzone\(/);
+  assert.match(src, /assetUpload\.createAssetManager\(/);
   assert.match(src, /assetUpload\.confirmDelete\(/);
+});
+
+test("both asset sections adopt createAssetManager; no direct createDropzone calls remain", async () => {
+  const src = await readFile(SRC, "utf8");
+  const managerCalls = src.match(/assetUpload\.createAssetManager\(/g) || [];
+  assert.equal(
+    managerCalls.length,
+    2,
+    "expected exactly two createAssetManager( calls (custom fonts + brand assets)",
+  );
+  assert.ok(
+    !/assetUpload\.createDropzone\(/.test(src),
+    "createDropzone must only be called from inside the shared module now",
+  );
 });
 
 test("theme.js owns zero raw upload plumbing after icon adoption", async () => {


### PR DESCRIPTION
## Summary

- **Shared upload pipeline**: new `utils/asset-upload.js` module — one `createAssetManager` composite (dropzone + table + inline confirm form + busy lock) drives both the Custom Fonts and Brand Asset Library sections; zero upload plumbing left in `theme.js`
- **Server-side gate**: `receive_upload` in rpcd unifies validation — 8MB cap for both kinds, woff2 magic bytes for fonts, extension allowlist (`jpg jpeg png webp avif svg gif ico`) + path rejection for images (previously images had **no** size/type validation at all); tmp cleanup owned server-side incl. the mv-failure leak
- **Fonts UX**: modal replaced by a dropzone-first flow — full-size drop target, auto family-name from filename, cbi-value confirm form, delete confirmation
- **Images UX**: editable filename on upload (rename to `login-bg.*` without re-uploading), collision warning before replacing an existing asset
- **Typography tab**: font library (upload + table) folded into the Typography section above the typeface selects; description rewritten to cover custom uploads and the on-save webfont fetch
- **Byte sizes** exposed by rpcd for both asset lists (`custom[].size`, `icon_sizes`)
- **i18n**: pot + 14 locales fully synced through every string change (268 msgids each, msgfmt clean)

## Verification

- 29/29 node tests, `sh -n` clean, JS parse checks
- Real-device (OpenWrt @ 192.168.10.1): 8/8 server-gate scenarios (oversize/bad-magic/traversal/ico-allowed/removals, tmp cleaned on every rejection), size fields live, UI flows exercised across 6 design iterations with user sign-off
- Multi-agent review: per-task reviews + two whole-scope reviews (all findings fixed and re-reviewed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)